### PR TITLE
Factory for initialization of monero_wallet_full subclasses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ set(
     src/daemon/monero_daemon.cpp
     src/wallet/monero_wallet_model.cpp
     src/wallet/monero_wallet_keys.cpp
+    src/wallet/monero_wallet_factory.cpp
     src/wallet/monero_wallet_full.cpp
 )
 
@@ -347,6 +348,7 @@ endif()
           src/utils/monero_utils.h
           DESTINATION include/utils)
   INSTALL(FILES src/wallet/monero_wallet_full.h
+          src/wallet/monero_wallet_factory.h
           src/wallet/monero_wallet.h
           src/wallet/monero_wallet_keys.h
           src/wallet/monero_wallet_model.h

--- a/src/wallet/monero_wallet_factory.cpp
+++ b/src/wallet/monero_wallet_factory.cpp
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) woodser
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Parts of this file are originally copyright (c) 2014-2019, The Monero Project
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * All rights reserved.
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+ */
+
+#include "monero_wallet_factory.h"
+#include "mnemonics/electrum-words.h"
+#include "utils/monero_utils.h"
+
+namespace monero {
+
+  struct wallet2_listener : public tools::i_wallet2_callback {
+    wallet2_listener(monero_wallet_full &wallet, tools::wallet2 &wallet2);
+    ~wallet2_listener();
+  };
+
+  monero_wallet_full* monero_wallet_factory::open_wallet(const std::string& path, const std::string& password, const monero_network_type network_type) {
+    MTRACE("open_wallet(" << path << ", ***, " << network_type << ")");
+    monero_wallet_full* wallet = create_origin();
+    wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true));
+    wallet->m_w2->load(path, password);
+    wallet->m_w2->init("");
+    wallet->init_common();
+    return wallet;
+  }
+
+  monero_wallet_full* monero_wallet_factory::open_wallet_data(const std::string& password, const monero_network_type network_type, const std::string& keys_data, const std::string& cache_data, const monero_rpc_connection& daemon_connection, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
+    MTRACE("open_wallet_data(...)");
+    monero_wallet_full* wallet = create_origin();
+    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true));
+    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true, std::move(http_client_factory)));
+    wallet->m_w2->load("", password, keys_data, cache_data);
+    wallet->m_w2->init("");
+    wallet->set_daemon_connection(daemon_connection);
+    wallet->init_common();
+    return wallet;
+  }
+
+  monero_wallet_full* monero_wallet_factory::create_wallet(const monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
+    MTRACE("create_wallet(config)");
+
+    // validate and normalize config
+    monero_wallet_config config_normalized = config.copy();
+    if (config.m_path == boost::none) config_normalized.m_path = std::string("");
+    if (config.m_password == boost::none) config_normalized.m_password = std::string("");
+    if (config.m_language == boost::none) config_normalized.m_language = std::string("");
+    if (config.m_seed == boost::none) config_normalized.m_seed = std::string("");
+    if (config.m_primary_address == boost::none) config_normalized.m_primary_address = std::string("");
+    if (config.m_private_spend_key == boost::none) config_normalized.m_private_spend_key = std::string("");
+    if (config.m_private_view_key == boost::none) config_normalized.m_private_view_key = std::string("");
+    if (config.m_seed_offset == boost::none) config_normalized.m_seed_offset = std::string("");
+    if (config.m_is_multisig == boost::none) config_normalized.m_is_multisig = false;
+    if (config.m_account_lookahead != boost::none && config.m_subaddress_lookahead == boost::none) throw std::runtime_error("No subaddress lookahead provided with account lookahead");
+    if (config.m_account_lookahead == boost::none && config.m_subaddress_lookahead != boost::none) throw std::runtime_error("No account lookahead provided with subaddress lookahead");
+    if (config_normalized.m_language.get().empty()) config_normalized.m_language = std::string("English");
+    if (!monero_utils::is_valid_language(config_normalized.m_language.get())) throw std::runtime_error("Unknown language: " + config_normalized.m_language.get());
+    if (config.m_network_type == boost::none) throw std::runtime_error("Must provide wallet network type");
+
+    // create wallet
+    if (!config_normalized.m_seed.get().empty()) {
+      return create_wallet_from_seed(config_normalized, std::move(http_client_factory));
+    } else if (!config_normalized.m_primary_address.get().empty() || !config_normalized.m_private_spend_key.get().empty() || !config_normalized.m_private_view_key.get().empty()) {
+      return create_wallet_from_keys(config_normalized, std::move(http_client_factory));
+    } else {
+      return create_wallet_random(config_normalized, std::move(http_client_factory));
+    }
+  }
+
+  monero_wallet_full* monero_wallet_factory::create_wallet_from_seed(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
+    MTRACE("create_wallet_from_seed(...)");
+
+    // normalize config
+    if (config.m_restore_height == boost::none) config.m_restore_height = 0;
+
+    // validate mnemonic and get recovery key and language if not multisig
+    crypto::secret_key recovery_key;
+    std::string language = config.m_language.get();
+    if (!config.m_is_multisig.get()) {
+      bool is_valid = crypto::ElectrumWords::words_to_bytes(config.m_seed.get(), recovery_key, language);
+      if (!is_valid) throw std::runtime_error("Invalid mnemonic");
+      if (language == crypto::ElectrumWords::old_language_name) language = config.m_language.get();
+    }
+
+    // validate language
+    if (!crypto::ElectrumWords::is_valid_language(language)) throw std::runtime_error("Invalid language: " + language);
+
+    // apply offset if given
+    if (!config.m_seed_offset.get().empty()) recovery_key = cryptonote::decrypt_key(recovery_key, config.m_seed_offset.get());
+
+    // initialize wallet
+    monero_wallet_full* wallet = create_origin();
+    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
+    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
+    wallet->set_daemon_connection(config.m_server);
+    wallet->m_w2->set_seed_language(language);
+    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
+
+    // generate wallet
+    if (config.m_is_multisig.get()) {
+
+      // parse multisig data
+      epee::wipeable_string multisig_data;
+      multisig_data.resize(config.m_seed.get().size() / 2);
+      if (!epee::from_hex::to_buffer(epee::to_mut_byte_span(multisig_data), config.m_seed.get())) throw std::runtime_error("Multisig seed not represented as hexadecimal string");
+
+      // generate multisig wallet
+      wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), multisig_data, false);
+      wallet->m_w2->enable_multisig(true);
+    } else {
+
+      // generate normal wallet
+      crypto::secret_key recovery_val = wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), recovery_key, true, false);
+
+      // validate mnemonic
+      epee::wipeable_string electrum_words;
+      if (!crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, language)) throw std::runtime_error("Failed to encode seed");
+    }
+    wallet->m_w2->set_refresh_from_block_height(config.m_restore_height.get());
+    wallet->init_common();
+    return wallet;
+  }
+
+  monero_wallet_full* monero_wallet_factory::create_wallet_from_keys(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
+    MTRACE("create_wallet_from_keys(...)");
+
+    // validate and normalize config
+    if (config.m_restore_height == boost::none) config.m_restore_height = 0;
+    if (!config.m_seed_offset.get().empty()) throw std::runtime_error("Cannot specify seed offset when creating wallet from keys");
+
+    // parse and validate private spend key
+    crypto::secret_key spend_key_sk;
+    bool has_spend_key = false;
+    if (!config.m_private_spend_key.get().empty()) {
+      cryptonote::blobdata spend_key_data;
+      if (!epee::string_tools::parse_hexstr_to_binbuff(config.m_private_spend_key.get(), spend_key_data) || spend_key_data.size() != sizeof(crypto::secret_key)) {
+        throw std::runtime_error("failed to parse secret spend key");
+      }
+      has_spend_key = true;
+      spend_key_sk = *reinterpret_cast<const crypto::secret_key*>(spend_key_data.data());
+    }
+
+    // parse and validate private view key
+    bool has_view_key = true;
+    crypto::secret_key view_key_sk;
+    if (config.m_private_view_key.get().empty()) {
+      if (has_spend_key) has_view_key = false;
+      else throw std::runtime_error("Neither spend key nor view key supplied");
+    }
+    if (has_view_key) {
+      cryptonote::blobdata view_key_data;
+      if (!epee::string_tools::parse_hexstr_to_binbuff(config.m_private_view_key.get(), view_key_data) || view_key_data.size() != sizeof(crypto::secret_key)) {
+        throw std::runtime_error("failed to parse secret view key");
+      }
+      view_key_sk = *reinterpret_cast<const crypto::secret_key*>(view_key_data.data());
+    }
+
+    // parse and validate address
+    cryptonote::address_parse_info address_info;
+    if (config.m_primary_address.get().empty()) {
+      if (has_view_key) throw std::runtime_error("must provide primary address if providing private view key");
+    } else {
+      if (!get_account_address_from_str(address_info, static_cast<cryptonote::network_type>(config.m_network_type.get()), config.m_primary_address.get())) throw std::runtime_error("failed to parse address");
+
+      // check the spend and view keys match the given address
+      crypto::public_key pkey;
+      if (has_spend_key) {
+        if (!crypto::secret_key_to_public_key(spend_key_sk, pkey)) throw std::runtime_error("failed to verify secret spend key");
+        if (address_info.address.m_spend_public_key != pkey) throw std::runtime_error("spend key does not match address");
+      }
+      if (has_view_key) {
+        if (!crypto::secret_key_to_public_key(view_key_sk, pkey)) throw std::runtime_error("failed to verify secret view key");
+        if (address_info.address.m_view_public_key != pkey) throw std::runtime_error("view key does not match address");
+      }
+    }
+
+    // validate language
+    if (!monero_utils::is_valid_language(config.m_language.get())) throw std::runtime_error("Unknown language: " + config.m_language.get());
+
+    // initialize wallet
+    // TODO: delete wallet pointer if exception
+    monero_wallet_full* wallet = create_origin();
+    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
+    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
+    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
+    if (has_spend_key && has_view_key) wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), address_info.address, spend_key_sk, view_key_sk);
+    else if (has_spend_key) wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), spend_key_sk, true, false);
+    else wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), address_info.address, view_key_sk);
+    wallet->set_daemon_connection(config.m_server);
+    wallet->m_w2->set_refresh_from_block_height(config.m_restore_height.get());
+    wallet->m_w2->set_seed_language(config.m_language.get());
+    wallet->init_common();
+    return wallet;
+  }
+
+  monero_wallet_full* monero_wallet_factory::create_wallet_random(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
+    MTRACE("create_wallet_random(...)");
+
+    // validate config
+    if (!config.m_seed_offset.get().empty()) throw std::runtime_error("Cannot specify seed offset when creating random wallet");
+    if (config.m_restore_height != boost::none) throw std::runtime_error("Cannot specify restore height when creating random wallet");
+
+    // initialize wallet
+    monero_wallet_full* wallet = create_origin();
+    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
+    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
+    wallet->set_daemon_connection(config.m_server);
+    wallet->m_w2->set_seed_language(config.m_language.get());
+    crypto::secret_key secret_key;
+    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
+    wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), secret_key, false, false);
+    wallet->init_common();
+    if (wallet->is_connected_to_daemon()) wallet->m_w2->set_refresh_from_block_height(wallet->get_daemon_height());
+    return wallet;
+  }
+
+  monero_wallet_full* monero_wallet_factory::create_origin() {
+    return new monero_wallet_full();
+  }
+}

--- a/src/wallet/monero_wallet_factory.h
+++ b/src/wallet/monero_wallet_factory.h
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) woodser
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Parts of this file are originally copyright (c) 2014-2019, The Monero Project
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * All rights reserved.
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ *    conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *    of conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+ */
+
+#pragma once
+
+#include "monero_wallet_full.h"
+
+namespace monero
+{
+
+  struct monero_wallet_factory
+  {
+
+    static monero_wallet_factory get_default()
+    {
+      return monero_wallet_factory();
+    }
+
+    /**
+     * Open an existing wallet from disk.
+     *
+     * @param path is the path to the wallet file to open
+     * @param password is the password of the wallet file to open
+     * @param network_type is the wallet's network type
+     * @return a pointer to the wallet instance
+     */
+    monero_wallet_full* open_wallet(const std::string &path, const std::string &password, const monero_network_type network_type);
+
+    /**
+     * Open an in-memory wallet from existing data buffers.
+     *
+     * @param password is the password of the wallet file to open
+     * @param network_type is the wallet's network type
+     * @param keys_data contains the contents of the ".keys" file
+     * @param cache_data contains the contents of the wallet cache file (no extension)
+     * @param daemon_connection is connection information to a daemon (default = an unconnected wallet)
+     * @param http_client_factory allows use of custom http clients
+     * @return a pointer to the wallet instance
+     */
+    monero_wallet_full* open_wallet_data(const std::string &password, const monero_network_type, const std::string &keys_data, const std::string &cache_data, const monero_rpc_connection &daemon_connection = monero_rpc_connection(), std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = nullptr);
+
+    /**
+     * Create a new wallet with the given configuration.
+     *
+     * @param config is the wallet configuration
+     * @param http_client_factory allows use of custom http clients
+     * @return a pointer to the wallet instance
+     */
+    monero_wallet_full* create_wallet(const monero_wallet_config &config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = nullptr);
+
+    monero_wallet_full* create_wallet_from_seed(monero_wallet_config &config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = nullptr);
+
+    monero_wallet_full* create_wallet_from_keys(monero_wallet_config &config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = nullptr);
+
+    monero_wallet_full* create_wallet_random(monero_wallet_config &config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory = nullptr);
+
+  protected:
+    virtual monero_wallet_full* create_origin();
+  };
+}

--- a/src/wallet/monero_wallet_full.cpp
+++ b/src/wallet/monero_wallet_full.cpp
@@ -67,6 +67,7 @@
 #include "serialization/binary_utils.h"
 #include "serialization/string.h"
 #include "common/threadpool.h"
+#include "monero_wallet_factory.h"
 
 using namespace tools;
 
@@ -1054,202 +1055,27 @@ namespace monero {
   }
 
   monero_wallet_full* monero_wallet_full::open_wallet(const std::string& path, const std::string& password, const monero_network_type network_type) {
-    MTRACE("open_wallet(" << path << ", ***, " << network_type << ")");
-    monero_wallet_full* wallet = new monero_wallet_full();
-    wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true));
-    wallet->m_w2->load(path, password);
-    wallet->m_w2->init("");
-    wallet->init_common();
-    return wallet;
+    return monero_wallet_factory::get_default().open_wallet(path, password, network_type);
   }
 
   monero_wallet_full* monero_wallet_full::open_wallet_data(const std::string& password, const monero_network_type network_type, const std::string& keys_data, const std::string& cache_data, const monero_rpc_connection& daemon_connection, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
-    MTRACE("open_wallet_data(...)");
-    monero_wallet_full* wallet = new monero_wallet_full();
-    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true));
-    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(network_type), 1, true, std::move(http_client_factory)));
-    wallet->m_w2->load("", password, keys_data, cache_data);
-    wallet->m_w2->init("");
-    wallet->set_daemon_connection(daemon_connection);
-    wallet->init_common();
-    return wallet;
+    return monero_wallet_factory::get_default().open_wallet_data(password, network_type, keys_data, cache_data, daemon_connection, std::move(http_client_factory));
   }
 
   monero_wallet_full* monero_wallet_full::create_wallet(const monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
-    MTRACE("create_wallet(config)");
-
-    // validate and normalize config
-    monero_wallet_config config_normalized = config.copy();
-    if (config.m_path == boost::none) config_normalized.m_path = std::string("");
-    if (config.m_password == boost::none) config_normalized.m_password = std::string("");
-    if (config.m_language == boost::none) config_normalized.m_language = std::string("");
-    if (config.m_seed == boost::none) config_normalized.m_seed = std::string("");
-    if (config.m_primary_address == boost::none) config_normalized.m_primary_address = std::string("");
-    if (config.m_private_spend_key == boost::none) config_normalized.m_private_spend_key = std::string("");
-    if (config.m_private_view_key == boost::none) config_normalized.m_private_view_key = std::string("");
-    if (config.m_seed_offset == boost::none) config_normalized.m_seed_offset = std::string("");
-    if (config.m_is_multisig == boost::none) config_normalized.m_is_multisig = false;
-    if (config.m_account_lookahead != boost::none && config.m_subaddress_lookahead == boost::none) throw std::runtime_error("No subaddress lookahead provided with account lookahead");
-    if (config.m_account_lookahead == boost::none && config.m_subaddress_lookahead != boost::none) throw std::runtime_error("No account lookahead provided with subaddress lookahead");
-    if (config_normalized.m_language.get().empty()) config_normalized.m_language = std::string("English");
-    if (!monero_utils::is_valid_language(config_normalized.m_language.get())) throw std::runtime_error("Unknown language: " + config_normalized.m_language.get());
-    if (config.m_network_type == boost::none) throw std::runtime_error("Must provide wallet network type");
-
-    // create wallet
-    if (!config_normalized.m_seed.get().empty()) {
-      return create_wallet_from_seed(config_normalized, std::move(http_client_factory));
-    } else if (!config_normalized.m_primary_address.get().empty() || !config_normalized.m_private_spend_key.get().empty() || !config_normalized.m_private_view_key.get().empty()) {
-      return create_wallet_from_keys(config_normalized, std::move(http_client_factory));
-    } else {
-      return create_wallet_random(config_normalized, std::move(http_client_factory));
-    }
+    return monero_wallet_factory::get_default().create_wallet(config, std::move(http_client_factory));
   }
 
   monero_wallet_full* monero_wallet_full::create_wallet_from_seed(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
-    MTRACE("create_wallet_from_seed(...)");
-
-    // normalize config
-    if (config.m_restore_height == boost::none) config.m_restore_height = 0;
-
-    // validate mnemonic and get recovery key and language if not multisig
-    crypto::secret_key recovery_key;
-    std::string language = config.m_language.get();
-    if (!config.m_is_multisig.get()) {
-      bool is_valid = crypto::ElectrumWords::words_to_bytes(config.m_seed.get(), recovery_key, language);
-      if (!is_valid) throw std::runtime_error("Invalid mnemonic");
-      if (language == crypto::ElectrumWords::old_language_name) language = config.m_language.get();
-    }
-
-    // validate language
-    if (!crypto::ElectrumWords::is_valid_language(language)) throw std::runtime_error("Invalid language: " + language);
-
-    // apply offset if given
-    if (!config.m_seed_offset.get().empty()) recovery_key = cryptonote::decrypt_key(recovery_key, config.m_seed_offset.get());
-
-    // initialize wallet
-    monero_wallet_full* wallet = new monero_wallet_full();
-    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
-    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
-    wallet->set_daemon_connection(config.m_server);
-    wallet->m_w2->set_seed_language(language);
-    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
-
-    // generate wallet
-    if (config.m_is_multisig.get()) {
-
-      // parse multisig data
-      epee::wipeable_string multisig_data;
-      multisig_data.resize(config.m_seed.get().size() / 2);
-      if (!epee::from_hex::to_buffer(epee::to_mut_byte_span(multisig_data), config.m_seed.get())) throw std::runtime_error("Multisig seed not represented as hexadecimal string");
-
-      // generate multisig wallet
-      wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), multisig_data, false);
-      wallet->m_w2->enable_multisig(true);
-    } else {
-
-      // generate normal wallet
-      crypto::secret_key recovery_val = wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), recovery_key, true, false);
-
-      // validate mnemonic
-      epee::wipeable_string electrum_words;
-      if (!crypto::ElectrumWords::bytes_to_words(recovery_val, electrum_words, language)) throw std::runtime_error("Failed to encode seed");
-    }
-    wallet->m_w2->set_refresh_from_block_height(config.m_restore_height.get());
-    wallet->init_common();
-    return wallet;
+    return monero_wallet_factory::get_default().create_wallet_from_seed(config, std::move(http_client_factory));
   }
 
   monero_wallet_full* monero_wallet_full::create_wallet_from_keys(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
-    MTRACE("create_wallet_from_keys(...)");
-
-    // validate and normalize config
-    if (config.m_restore_height == boost::none) config.m_restore_height = 0;
-    if (!config.m_seed_offset.get().empty()) throw std::runtime_error("Cannot specify seed offset when creating wallet from keys");
-
-    // parse and validate private spend key
-    crypto::secret_key spend_key_sk;
-    bool has_spend_key = false;
-    if (!config.m_private_spend_key.get().empty()) {
-      cryptonote::blobdata spend_key_data;
-      if (!epee::string_tools::parse_hexstr_to_binbuff(config.m_private_spend_key.get(), spend_key_data) || spend_key_data.size() != sizeof(crypto::secret_key)) {
-        throw std::runtime_error("failed to parse secret spend key");
-      }
-      has_spend_key = true;
-      spend_key_sk = *reinterpret_cast<const crypto::secret_key*>(spend_key_data.data());
-    }
-
-    // parse and validate private view key
-    bool has_view_key = true;
-    crypto::secret_key view_key_sk;
-    if (config.m_private_view_key.get().empty()) {
-      if (has_spend_key) has_view_key = false;
-      else throw std::runtime_error("Neither spend key nor view key supplied");
-    }
-    if (has_view_key) {
-      cryptonote::blobdata view_key_data;
-      if (!epee::string_tools::parse_hexstr_to_binbuff(config.m_private_view_key.get(), view_key_data) || view_key_data.size() != sizeof(crypto::secret_key)) {
-        throw std::runtime_error("failed to parse secret view key");
-      }
-      view_key_sk = *reinterpret_cast<const crypto::secret_key*>(view_key_data.data());
-    }
-
-    // parse and validate address
-    cryptonote::address_parse_info address_info;
-    if (config.m_primary_address.get().empty()) {
-      if (has_view_key) throw std::runtime_error("must provide primary address if providing private view key");
-    } else {
-      if (!get_account_address_from_str(address_info, static_cast<cryptonote::network_type>(config.m_network_type.get()), config.m_primary_address.get())) throw std::runtime_error("failed to parse address");
-
-      // check the spend and view keys match the given address
-      crypto::public_key pkey;
-      if (has_spend_key) {
-        if (!crypto::secret_key_to_public_key(spend_key_sk, pkey)) throw std::runtime_error("failed to verify secret spend key");
-        if (address_info.address.m_spend_public_key != pkey) throw std::runtime_error("spend key does not match address");
-      }
-      if (has_view_key) {
-        if (!crypto::secret_key_to_public_key(view_key_sk, pkey)) throw std::runtime_error("failed to verify secret view key");
-        if (address_info.address.m_view_public_key != pkey) throw std::runtime_error("view key does not match address");
-      }
-    }
-
-    // validate language
-    if (!monero_utils::is_valid_language(config.m_language.get())) throw std::runtime_error("Unknown language: " + config.m_language.get());
-
-    // initialize wallet
-    // TODO: delete wallet pointer if exception
-    monero_wallet_full* wallet = new monero_wallet_full();
-    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
-    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
-    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
-    if (has_spend_key && has_view_key) wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), address_info.address, spend_key_sk, view_key_sk);
-    else if (has_spend_key) wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), spend_key_sk, true, false);
-    else wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), address_info.address, view_key_sk);
-    wallet->set_daemon_connection(config.m_server);
-    wallet->m_w2->set_refresh_from_block_height(config.m_restore_height.get());
-    wallet->m_w2->set_seed_language(config.m_language.get());
-    wallet->init_common();
-    return wallet;
+    return monero_wallet_factory::get_default().create_wallet_from_keys(config, std::move(http_client_factory));
   }
 
   monero_wallet_full* monero_wallet_full::create_wallet_random(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory) {
-    MTRACE("create_wallet_random(...)");
-
-    // validate config
-    if (!config.m_seed_offset.get().empty()) throw std::runtime_error("Cannot specify seed offset when creating random wallet");
-    if (config.m_restore_height != boost::none) throw std::runtime_error("Cannot specify restore height when creating random wallet");
-
-    // initialize wallet
-    monero_wallet_full* wallet = new monero_wallet_full();
-    if (http_client_factory == nullptr) wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true));
-    else wallet->m_w2 = std::unique_ptr<tools::wallet2>(new tools::wallet2(static_cast<cryptonote::network_type>(config.m_network_type.get()), 1, true, std::move(http_client_factory)));
-    wallet->set_daemon_connection(config.m_server);
-    wallet->m_w2->set_seed_language(config.m_language.get());
-    crypto::secret_key secret_key;
-    if (config.m_account_lookahead != boost::none) wallet->m_w2->set_subaddress_lookahead(config.m_account_lookahead.get(), config.m_subaddress_lookahead.get());
-    wallet->m_w2->generate(config.m_path.get(), config.m_password.get(), secret_key, false, false);
-    wallet->init_common();
-    if (wallet->is_connected_to_daemon()) wallet->m_w2->set_refresh_from_block_height(wallet->get_daemon_height());
-    return wallet;
+    return monero_wallet_factory::get_default().create_wallet_random(config, std::move(http_client_factory));
   }
 
   std::vector<std::string> monero_wallet_full::get_seed_languages() {

--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -64,6 +64,8 @@
  */
 namespace monero {
 
+  struct monero_wallet_factory;
+
   // -------------------------------- LISTENERS -------------------------------
 
   // forward declaration of internal wallet2 listener
@@ -257,9 +259,12 @@ namespace monero {
   protected:
     std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
 
+    void init_common();
+
   // ---------------------------------- PRIVATE ---------------------------------
 
   private:
+    friend struct monero_wallet_factory;
     friend struct wallet2_listener;
     std::unique_ptr<wallet2_listener> m_w2_listener; // internal wallet implementation listener
     std::set<monero_wallet_listener*> m_listeners;   // external wallet listeners
@@ -268,7 +273,6 @@ namespace monero {
     static monero_wallet_full* create_wallet_from_keys(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory);
     static monero_wallet_full* create_wallet_random(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory);
 
-    void init_common();
     std::vector<monero_subaddress> get_subaddresses_aux(uint32_t account_idx, const std::vector<uint32_t>& subaddress_indices, const std::vector<tools::wallet2::transfer_details>& transfers) const;
     std::vector<std::shared_ptr<monero_transfer>> get_transfers_aux(const monero_transfer_query& query) const;
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs_aux(const monero_output_query& query) const;


### PR DESCRIPTION
Adding to the previous pull request: https://github.com/monero-ecosystem/monero-cpp/pull/45 and https://github.com/monero-ecosystem/monero-cpp/pull/41

Initialization of **monero_wallet_full** and its subclasses has been moved to the abstract factory **monero_wallet_factory**. This change helps prevent code duplication during the initialization of **monero_wallet_full** subclasses.

_The modification should not impact the functionality of the existing code (please double-check)._