### PR TITLE
Fix building sample_code.cpp on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,6 @@ if (BUILD_SAMPLE)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -420,6 +419,7 @@ if (BUILD_SAMPLE)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks


### PR DESCRIPTION
Fixed incorrect link order.

Fixes #75