### PR TITLE
Bump ICU to v75.1-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ For example, [monero-java](https://github.com/woodser/monero-java) compiles this
 
      ```
      pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-unbound mingw-w64-x86_64-protobuf git mingw-w64-x86_64-libusb gettext base-devel
-     wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-75.1-1-any.pkg.tar.zst
-     pacman -U mingw-w64-x86_64-icu-75.1-1-any.pkg.tar.zst
+     wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
+     pacman -U mingw-w64-x86_64-icu-75.1-2-any.pkg.tar.zst
      wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-boost-1.85.0-4-any.pkg.tar.zst
      pacman -U mingw-w64-x86_64-boost-1.85.0-4-any.pkg.tar.zst
      ```


### PR DESCRIPTION
Updated README with new version for ICU (v75.1-2), since package `mingw-w64-x86_64-icu-75.1-1-any.pkg.tar.zst` is not available anymore in [msys2 mingw64 repository](https://repo.msys2.org/mingw/mingw64/).