### PR TITLE
wallet: support offset in key image export and import

### DIFF
--- a/src/wallet/monero_wallet.h
+++ b/src/wallet/monero_wallet.h
@@ -820,9 +820,9 @@ namespace monero {
      * Export signed key images.
      *
      * @param all - export all key images if true, else export key images since the last export
-     * @return the wallet's signed key images
+     * @return the wallet's signed key images and their offset among the wallet's outputs
      */
-    virtual std::vector<std::shared_ptr<monero_key_image>> export_key_images(bool all = false) const {
+    virtual std::shared_ptr<monero_key_image_export_result> export_key_images(bool all = false) const {
       throw std::runtime_error("export_key_images() not supported");
     }
 
@@ -830,9 +830,10 @@ namespace monero {
      * Import signed key images and verify their spent status.
      *
      * @param key_images are key images to import and verify (requires hex and signature)
+     * @param offset - offset of the first key image among the wallet's outputs (default 0)
      * @return results of the import
      */
-    virtual std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images) {
+    virtual std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images, uint64_t offset = 0) {
       throw std::runtime_error("import_key_images() not supported");
     }
 

--- a/src/wallet/monero_wallet_full.cpp
+++ b/src/wallet/monero_wallet_full.cpp
@@ -1871,24 +1871,25 @@ namespace monero {
     return m_w2->import_outputs_from_str(blob);
   }
 
-  std::vector<std::shared_ptr<monero_key_image>> monero_wallet_full::export_key_images(bool all) const {
+  std::shared_ptr<monero_key_image_export_result> monero_wallet_full::export_key_images(bool all) const {
     MTRACE("monero_wallet_full::export_key_images()");
     assert_not_closed();
 
-    // build key images from wallet2 types
-    std::vector<std::shared_ptr<monero_key_image>> key_images;
+    // build export result from wallet2 types
+    std::shared_ptr<monero_key_image_export_result> result = std::make_shared<monero_key_image_export_result>();
     sync_op_lock op_lock(*this); // do not refresh while exporting key images
     std::pair<uint64_t, std::vector<std::pair<crypto::key_image, crypto::signature>>> ski = m_w2->export_key_images(all);
+    result->m_offset = ski.first;
     for (uint64_t n = 0; n < ski.second.size(); ++n) {
       std::shared_ptr<monero_key_image> key_image = std::make_shared<monero_key_image>();
-      key_images.push_back(key_image);
+      result->m_key_images.push_back(key_image);
       key_image->m_hex = epee::string_tools::pod_to_hex(ski.second[n].first);
       key_image->m_signature = epee::string_tools::pod_to_hex(ski.second[n].second);
     }
-    return key_images;
+    return result;
   }
 
-  std::shared_ptr<monero_key_image_import_result> monero_wallet_full::import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images) {
+  std::shared_ptr<monero_key_image_import_result> monero_wallet_full::import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images, uint64_t offset) {
     MTRACE("monero_wallet_full::import_key_images()");
     assert_not_closed();
 
@@ -1907,7 +1908,7 @@ namespace monero {
     // import key images
     uint64_t spent = 0, unspent = 0;
     sync_op_lock op_lock(*this); // do not refresh while importing key images
-    uint64_t height = m_w2->import_key_images(ski, 0, spent, unspent, is_connected_to_daemon()); // TODO: use offset? refer to wallet_rpc_server::on_import_key_images() req.offset
+    uint64_t height = m_w2->import_key_images(ski, offset, spent, unspent, is_connected_to_daemon());
 
     // translate results
     std::shared_ptr<monero_key_image_import_result> result = std::make_shared<monero_key_image_import_result>();

--- a/src/wallet/monero_wallet_full.cpp
+++ b/src/wallet/monero_wallet_full.cpp
@@ -2806,6 +2806,7 @@ namespace monero {
         for (const crypto::secret_key& additional_tx_key : ptx.additional_tx_keys) {
             tx->m_key = tx->m_key.get() += epee::string_tools::pod_to_hex(unwrap(unwrap(additional_tx_key)));
         }
+        tx->m_full_hex = epee::string_tools::buff_to_hex_nodelimer(cryptonote::tx_to_blob(ptx.tx));
         tx_set.m_txs.push_back(tx);
       }
       return tx_set;

--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -196,8 +196,8 @@ namespace monero {
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs(const monero_output_query& query) const override;
     std::string export_outputs(bool all = false) const override;
     int import_outputs(const std::string& outputs_hex) override;
-    std::vector<std::shared_ptr<monero_key_image>> export_key_images(bool all = false) const override;
-    std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images) override;
+    std::shared_ptr<monero_key_image_export_result> export_key_images(bool all = false) const override;
+    std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images, uint64_t offset = 0) override;
     void freeze_output(const std::string& key_image) override;
     void thaw_output(const std::string& key_image) override;
     bool is_output_frozen(const std::string& key_image) override;

--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -1471,6 +1471,47 @@ namespace monero {
     }
   }
 
+  // -------------------- MONERO KEY IMAGE EXPORT RESULT ----------------------
+
+  rapidjson::Value monero_key_image_export_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
+
+    // create root
+    rapidjson::Value root(rapidjson::kObjectType);
+
+    // set num values
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    if (m_offset != boost::none) monero_utils::add_json_member("offset", m_offset.get(), allocator, root, value_num);
+
+    // set sub-arrays
+    if (!m_key_images.empty()) root.AddMember("keyImages", monero_utils::to_rapidjson_val(allocator, m_key_images), allocator);
+
+    // return root
+    return root;
+  }
+
+  std::shared_ptr<monero_key_image_export_result> monero_key_image_export_result::deserialize(const std::string& result_json) {
+
+    // deserialize json to property node
+    std::istringstream iss = result_json.empty() ? std::istringstream() : std::istringstream(result_json);
+    boost::property_tree::ptree node;
+    boost::property_tree::read_json(iss, node);
+
+    // convert property tree to export result
+    std::shared_ptr<monero_key_image_export_result> result = std::make_shared<monero_key_image_export_result>();
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("offset")) result->m_offset = it->second.get_value<uint64_t>();
+      else if (key == std::string("keyImages")) {
+        for (boost::property_tree::ptree::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
+          std::shared_ptr<monero_key_image> key_image = std::make_shared<monero_key_image>();
+          monero_key_image::from_property_tree(it2->second, key_image);
+          result->m_key_images.push_back(key_image);
+        }
+      }
+    }
+    return result;
+  }
+
   // -------------------- MONERO KEY IMAGE IMPORT RESULT ----------------------
 
   void monero_key_image_import_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_import_result>& result) {

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -416,6 +416,17 @@ namespace monero {
   };
 
   /**
+   * Models results from exporting signed key images.
+   */
+  struct monero_key_image_export_result : public serializable_struct {
+    boost::optional<uint64_t> m_offset;
+    std::vector<std::shared_ptr<monero_key_image>> m_key_images;
+
+    rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static std::shared_ptr<monero_key_image_export_result> deserialize(const std::string& result_json);
+  };
+
+  /**
    * Models results from importing key images.
    */
   struct monero_key_image_import_result : public serializable_struct {

--- a/src/wallet/monero_wallet_rpc.cpp
+++ b/src/wallet/monero_wallet_rpc.cpp
@@ -951,18 +951,18 @@ namespace monero {
     return deserialize_num_imported_outputs(result);
   }
 
-  std::vector<std::shared_ptr<monero_key_image>> monero_wallet_rpc::export_key_images(bool all) const {
+  std::shared_ptr<monero_key_image_export_result> monero_wallet_rpc::export_key_images(bool all) const {
     MTRACE("monero_wallet_rpc::export_key_images()");
     auto params = std::make_shared<monero_wallet_data_params>(all);
     auto result = m_rpc->send_json_request("export_key_images", params);
-    std::vector<std::shared_ptr<monero_key_image>> key_images;
-    deserialize_key_images(result, key_images);
-    return key_images;
+    auto export_result = std::make_shared<monero_key_image_export_result>();
+    deserialize_key_image_export_result(result, export_result);
+    return export_result;
   }
 
-  std::shared_ptr<monero_key_image_import_result> monero_wallet_rpc::import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images) {
+  std::shared_ptr<monero_key_image_import_result> monero_wallet_rpc::import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images, uint64_t offset) {
     MTRACE("monero_wallet_rpc::import_key_images()");
-    auto params = std::make_shared<monero_wallet_data_params>(key_images);
+    auto params = std::make_shared<monero_wallet_data_params>(key_images, offset);
     auto result = m_rpc->send_json_request("import_key_images", params);
     auto import_result = std::make_shared<monero_key_image_import_result>();
     deserialize_key_image_import_result(result, import_result);

--- a/src/wallet/monero_wallet_rpc.cpp
+++ b/src/wallet/monero_wallet_rpc.cpp
@@ -1204,6 +1204,8 @@ namespace monero {
 
   monero_tx_set monero_wallet_rpc::sign_txs(const std::string& unsigned_tx_hex) {
     auto params = std::make_shared<monero_sign_describe_transfer_params>(unsigned_tx_hex);
+    params->m_export_raw = true;
+    params->m_get_tx_keys = true;
     auto result = m_rpc->send_json_request("sign_transfer", params);
     auto set = std::make_shared<monero_tx_set>();
     deserialize_sent_tx_set(result, set);

--- a/src/wallet/monero_wallet_rpc.h
+++ b/src/wallet/monero_wallet_rpc.h
@@ -186,8 +186,8 @@ namespace monero {
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs(const monero_output_query& query) const override;
     std::string export_outputs(bool all = false) const override;
     int import_outputs(const std::string& outputs_hex) override;
-    std::vector<std::shared_ptr<monero_key_image>> export_key_images(bool all = false) const override;
-    std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images) override;
+    std::shared_ptr<monero_key_image_export_result> export_key_images(bool all = false) const override;
+    std::shared_ptr<monero_key_image_import_result> import_key_images(const std::vector<std::shared_ptr<monero_key_image>>& key_images, uint64_t offset = 0) override;
     void freeze_output(const std::string& key_image) override;
     void thaw_output(const std::string& key_image) override;
     bool is_output_frozen(const std::string& key_image) override;

--- a/src/wallet/monero_wallet_rpc_model.cpp
+++ b/src/wallet/monero_wallet_rpc_model.cpp
@@ -183,6 +183,10 @@ namespace monero {
     // set bool values
     if (m_all != boost::none) monero_utils::add_json_member("all", m_all.get(), allocator, root);
 
+    // set num values
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    if (m_offset != boost::none) monero_utils::add_json_member("offset", m_offset.get(), allocator, root, value_num);
+
     // set sub-arrays
     std::vector<std::shared_ptr<monero_rpc_key_image>> signed_key_images;
     for (const auto& ki : m_key_images) signed_key_images.push_back(std::make_shared<monero_rpc_key_image>(ki));
@@ -1584,16 +1588,17 @@ namespace monero {
     }
   }
 
-  void deserialize_key_images(const boost::property_tree::ptree& node, std::vector<std::shared_ptr<monero_key_image>>& key_images) {
+  void deserialize_key_image_export_result(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_export_result>& result) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
-      if (key == std::string("signed_key_images")) {
+      if (key == std::string("offset")) result->m_offset = it->second.get_value<uint64_t>();
+      else if (key == std::string("signed_key_images")) {
         auto key_images_node = it->second;
 
         for (auto it2 = key_images_node.begin(); it2 != key_images_node.end(); ++it2) {
           auto key_image = std::make_shared<monero_key_image>();
           deserialize_key_image(it2->second, key_image);
-          key_images.push_back(key_image);
+          result->m_key_images.push_back(key_image);
         }
       }
     }

--- a/src/wallet/monero_wallet_rpc_model.cpp
+++ b/src/wallet/monero_wallet_rpc_model.cpp
@@ -575,6 +575,10 @@ namespace monero {
     if (m_unsigned_txset != boost::none) monero_utils::add_json_member("unsigned_txset", m_unsigned_txset.get(), allocator, root, value_str);
     if (m_multisig_txset != boost::none) monero_utils::add_json_member("multisig_txset", m_multisig_txset.get(), allocator, root, value_str);
 
+    // set bool values
+    if (m_export_raw != boost::none) monero_utils::add_json_member("export_raw", m_export_raw.get(), allocator, root);
+    if (m_get_tx_keys != boost::none) monero_utils::add_json_member("get_tx_keys", m_get_tx_keys.get(), allocator, root);
+
     // return root
     return root;
   }
@@ -1361,7 +1365,7 @@ namespace monero {
           i++;
         }
       }
-      else if (key == std::string("tx_blob_list")) {
+      else if (key == std::string("tx_blob_list") || key == std::string("tx_raw_list")) {
         auto node2 = it->second;
         int i = 0;
         for (auto it2 = node2.begin(); it2 != node2.end(); ++it2) {

--- a/src/wallet/monero_wallet_rpc_model.h
+++ b/src/wallet/monero_wallet_rpc_model.h
@@ -271,6 +271,8 @@ namespace monero {
   struct monero_sign_describe_transfer_params : public serializable_struct {
     boost::optional<std::string> m_unsigned_txset;
     boost::optional<std::string> m_multisig_txset;
+    boost::optional<bool> m_export_raw;
+    boost::optional<bool> m_get_tx_keys;
 
     monero_sign_describe_transfer_params() { }
     monero_sign_describe_transfer_params(const std::string &unsigned_txset) : m_unsigned_txset(unsigned_txset) { }

--- a/src/wallet/monero_wallet_rpc_model.h
+++ b/src/wallet/monero_wallet_rpc_model.h
@@ -323,9 +323,10 @@ namespace monero {
   struct monero_wallet_data_params : public serializable_struct {
     boost::optional<bool> m_all;
     std::vector<std::shared_ptr<monero_key_image>> m_key_images;
+    boost::optional<uint64_t> m_offset;
     boost::optional<std::string> m_outputs_hex;
 
-    monero_wallet_data_params(const std::vector<std::shared_ptr<monero_key_image>> &key_images): m_key_images(key_images) { };
+    monero_wallet_data_params(const std::vector<std::shared_ptr<monero_key_image>> &key_images, uint64_t offset): m_key_images(key_images), m_offset(offset) { };
     monero_wallet_data_params(bool all): m_all(all) { }
     monero_wallet_data_params(const std::string& outputs_hex): m_outputs_hex(outputs_hex) { }
 
@@ -472,7 +473,7 @@ namespace monero {
   std::string deserialize_tx_key(const boost::property_tree::ptree& node);
   void deserialize_tx_notes(const boost::property_tree::ptree& node, std::vector<std::string>& tx_notes);
   void deserialize_integrated_address(const boost::property_tree::ptree& node, monero_integrated_address& subaddress);
-  void deserialize_key_images(const boost::property_tree::ptree& node, std::vector<std::shared_ptr<monero_key_image>>& key_images);
+  void deserialize_key_image_export_result(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_export_result>& result);
   void deserialize_key_image_import_result(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_import_result>& result);
   void deserialize_message_signature_result(const boost::property_tree::ptree& node, monero_message_signature_result& result);
   void deserialize_check_tx(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check_tx>& check);


### PR DESCRIPTION
Adds monero_key_image_export_result with the offset from wallet2/wallet RPC and an offset parameter on import_key_images().