### PR TITLE
ci: generate release notes in the draft release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,5 +399,7 @@ jobs:
       - name: Attach archives to release
         uses: softprops/action-gh-release@v2
         with:
+          name: monero-cpp-${{ github.ref_name }}
           files: release/*
-          draft: true # publish manually after reviewing the notes
+          generate_release_notes: true
+          draft: true # publish this draft after reviewing the notes; a separate release would have no assets


### PR DESCRIPTION
The release job creates its own draft, so notes written in a separately created release leave that release without the build assets.