### PR TITLE
fix public data model deserialization

### DIFF
--- a/src/common/monero_rpc_connection.cpp
+++ b/src/common/monero_rpc_connection.cpp
@@ -433,6 +433,8 @@ namespace monero {
       else if (key == std::string("password")) connection->m_password = it->second.data();
       else if (key == std::string("proxyUri") || key == std::string("proxy_uri")) connection->m_proxy_uri = it->second.data();
       else if (key == std::string("zmqUri")) connection->m_zmq_uri = it->second.data();
+      else if (key == std::string("priority")) connection->m_priority = it->second.get_value<int>();
+      else if (key == std::string("timeoutMs")) connection->m_timeout_ms = it->second.get_value<uint32_t>();
     }
     return connection;
   }

--- a/src/daemon/monero_daemon_model.cpp
+++ b/src/daemon/monero_daemon_model.cpp
@@ -803,7 +803,7 @@ namespace monero {
   void monero_prune_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_prune_result>& result) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
-      if (key == std::string("pruned")) result->m_is_pruned = it->second.get_value<bool>();
+      if (key == std::string("isPruned")) result->m_is_pruned = it->second.get_value<bool>();
       else if (key == std::string("pruningSeed")) result->m_pruning_seed = it->second.get_value<int>();
     }
   }
@@ -982,6 +982,7 @@ namespace monero {
       else if (key == std::string("avgUpload")) peer->m_avg_upload = it->second.get_value<uint64_t>();
       else if (key == std::string("hash")) peer->m_hash = it->second.data();
       else if (key == std::string("height")) peer->m_height = it->second.get_value<uint64_t>();
+      else if (key == std::string("isOnline")) peer->m_is_online = it->second.get_value<bool>();
       else if (key == std::string("isIncoming")) peer->m_is_incoming = it->second.get_value<bool>();
       else if (key == std::string("liveTime")) peer->m_live_time = it->second.get_value<uint64_t>();
       else if (key == std::string("isLocalIp")) peer->m_is_local_ip = it->second.get_value<bool>();
@@ -1042,6 +1043,7 @@ namespace monero {
     if (m_receive_idle_time != boost::none) monero_utils::add_json_member("receiveIdleTime", m_receive_idle_time.get(), allocator, root, value_num);
     if (m_send_idle_time != boost::none) monero_utils::add_json_member("sendIdleTime", m_send_idle_time.get(), allocator, root, value_num);
     if (m_num_support_flags != boost::none) monero_utils::add_json_member("numSupportFlags", m_num_support_flags.get(), allocator, root, value_num);
+    if (m_connection_type != boost::none) monero_utils::add_json_member("addressType", (int)m_connection_type.get(), allocator, root, value_num);
 
     // set bool values
     if (m_is_online != boost::none) monero_utils::add_json_member("isOnline", m_is_online.get(), allocator, root);
@@ -1060,7 +1062,8 @@ namespace monero {
 
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
-      if (key == std::string("isDoubleSpend")) result->m_is_double_spend = it->second.get_value<bool>();
+      if (key == std::string("isGood")) result->m_is_good = it->second.get_value<bool>();
+      else if (key == std::string("isDoubleSpend")) result->m_is_double_spend = it->second.get_value<bool>();
       else if (key == std::string("isFeeTooLow")) result->m_is_fee_too_low = it->second.get_value<bool>();
       else if (key == std::string("hasInvalidInput")) result->m_has_invalid_input = it->second.get_value<bool>();
       else if (key == std::string("hasInvalidOutput")) result->m_has_invalid_output = it->second.get_value<bool>();
@@ -1181,7 +1184,9 @@ namespace monero {
       else if (key == std::string("histo98pc")) stats->m_histo98pc = it->second.get_value<uint64_t>();
       else if (key == std::string("oldestTimestamp")) stats->m_oldest_timestamp = it->second.get_value<uint64_t>();
       else if (key == std::string("histo")) {
-        // TODO implement histogram deserialization
+        for (const auto& child : it->second) {
+          stats->m_histo[std::stoull(child.first)] = child.second.get_value<uint64_t>();
+        }
       }
     }
   }
@@ -1414,6 +1419,20 @@ namespace monero {
       else if (key == std::string("targetHeight")) info->m_target_height = it->second.get_value<uint64_t>();
       else if (key == std::string("nextNeededPruningSeed")) info->m_next_needed_pruning_seed = it->second.get_value<int>();
       else if (key == std::string("overview") && !it->second.data().empty() && it->second.data() != std::string("[]")) info->m_overview = it->second.data();
+      else if (key == std::string("peers")) {
+        for (const auto& child : it->second) {
+          std::shared_ptr<monero_peer> peer = std::make_shared<monero_peer>();
+          monero_peer::from_property_tree(child.second, peer);
+          info->m_peers.push_back(peer);
+        }
+      }
+      else if (key == std::string("spans")) {
+        for (const auto& child : it->second) {
+          std::shared_ptr<monero_connection_span> span = std::make_shared<monero_connection_span>();
+          monero_connection_span::from_property_tree(child.second, span);
+          info->m_spans.push_back(span);
+        }
+      }
     }
   }
 

--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -221,6 +221,13 @@ namespace monero {
       else if (key == std::string("unlockedBalance")) account->m_unlocked_balance = it->second.get_value<uint64_t>();
       else if (key == std::string("primaryAddress")) account->m_primary_address = it->second.data();
       else if (key == std::string("tag") && !it->second.data().empty()) account->m_tag = it->second.data();
+      else if (key == std::string("subaddresses")) {
+        for (const auto& child : it->second) {
+          std::shared_ptr<monero_subaddress> subaddress = std::make_shared<monero_subaddress>();
+          monero_subaddress::from_property_tree(child.second, subaddress);
+          account->m_subaddresses.push_back(*subaddress);
+        }
+      }
     }
   }
 
@@ -499,8 +506,6 @@ namespace monero {
     if (m_max_height != boost::none) monero_utils::add_json_member("maxHeight", m_max_height.get(), allocator, root, value_num);
 
     // set bool values
-    if (m_is_outgoing != boost::none) monero_utils::add_json_member("isOutgoing", m_is_outgoing.get(), allocator, root);
-    if (m_is_incoming != boost::none) monero_utils::add_json_member("isIncoming", m_is_incoming.get(), allocator, root);
     if (m_has_payment_id != boost::none) monero_utils::add_json_member("hasPaymentId", m_has_payment_id.get(), allocator, root);
     if (m_include_outputs != boost::none) monero_utils::add_json_member("includeOutputs", m_include_outputs.get(), allocator, root);
 
@@ -521,9 +526,7 @@ namespace monero {
     // initialize query from node
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
-      if (key == std::string("isOutgoing")) tx_query->m_is_outgoing = it->second.get_value<bool>();
-      else if (key == std::string("isIncoming")) tx_query->m_is_incoming = it->second.get_value<bool>();
-      else if (key == std::string("hashes")) for (boost::property_tree::ptree::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) tx_query->m_hashes.push_back(it2->second.data());
+      if (key == std::string("hashes")) for (boost::property_tree::ptree::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) tx_query->m_hashes.push_back(it2->second.data());
       else if (key == std::string("hasPaymentId")) tx_query->m_has_payment_id = it->second.get_value<bool>();
       else if (key == std::string("paymentIds")) for (boost::property_tree::ptree::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) tx_query->m_payment_ids.push_back(it2->second.data());
       else if (key == std::string("height")) tx_query->m_height = it->second.get_value<uint64_t>();

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -311,8 +311,6 @@ namespace monero {
    * All transactions are returned except those that do not meet the criteria defined in this query.
    */
   struct monero_tx_query : public monero_tx_wallet {
-    boost::optional<bool> m_is_outgoing;
-    boost::optional<bool> m_is_incoming;
     std::vector<std::string> m_hashes;
     boost::optional<bool> m_has_payment_id;
     std::vector<std::string> m_payment_ids;


### PR DESCRIPTION
* Fix missing keys `priority` and `timeoutMs` in `monero_rpc_connection::from_property_tree` deserialization
* Fix missing key `isPruned` in `monero_prune_result::from_property_tree` deserialization
* Fix missing key `isGood` in `monero_submit_tx_result::from_property_tree` deserialization
* Fix missing key `isOnline` in `monero_peer::from_property_tree` deserialization
* Fix missing key `addressType` in `monero_peer::to_rapidjson_val` serialization
* Fix missing keys `peers` and `spans` in `monero_daemon_sync_info::from_property_tree` deserialization
* Fix missing key `subaddresses` in `monero_account::from_property_tree` deserialization
* Implement missing `histo` deserialization in `monero_tx_pool_stats::from_property_tree`
* Remove duplicated `monero_tx_query::m_is_incoming` and `monero_tx_query::m_is_outgoing` since they are already defined in super class `monero_tx_wallet`, causing duplicated keys in json serialization