### PR TITLE
monero_tx_wallet: add other utility functions

### DIFF
--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -469,6 +469,17 @@ namespace monero {
     m_extra_hex = gen_utils::reconcile(m_extra_hex, other->m_extra_hex, "tx wallet m_extra_hex");
   }
 
+  uint64_t monero_tx_wallet::get_incoming_amount() const {
+    uint64_t amount = 0;
+    for (const auto& transfer : m_incoming_transfers) amount += transfer->m_amount.value_or(0);
+    return amount;
+  }
+
+  uint64_t monero_tx_wallet::get_outgoing_amount() const {
+    if (m_outgoing_transfer == nullptr) return 0;
+    return m_outgoing_transfer->m_amount.value_or(0);
+  }
+
   std::vector<std::shared_ptr<monero_transfer>> monero_tx_wallet::get_transfers() const {
     monero_transfer_query query;
     return get_transfers(query);
@@ -499,6 +510,35 @@ namespace monero {
       }
     }
     return transfers;
+  }
+
+  std::vector<std::shared_ptr<monero_output_wallet>> monero_tx_wallet::get_inputs_wallet() const {
+    monero_output_query query;
+    return get_inputs_wallet(query);
+  }
+
+  std::vector<std::shared_ptr<monero_output_wallet>> monero_tx_wallet::get_inputs_wallet(const monero_output_query& query) const {
+    std::vector<std::shared_ptr<monero_output_wallet>> inputs;
+    for (const std::shared_ptr<monero_output>& input : m_inputs) {
+      std::shared_ptr<monero_output_wallet> input_wallet = std::dynamic_pointer_cast<monero_output_wallet>(input);
+      if (query.meets_criteria(input_wallet.get())) inputs.push_back(input_wallet);
+    }
+    return inputs;
+  }
+
+  std::vector<std::shared_ptr<monero_output_wallet>> monero_tx_wallet::filter_inputs_wallet(const monero_output_query& query) {
+    std::vector<std::shared_ptr<monero_output_wallet>> inputs;
+    std::vector<std::shared_ptr<monero_output>>::iterator iter = m_inputs.begin();
+    while (iter != m_inputs.end()) {
+      std::shared_ptr<monero_output_wallet> input_wallet = std::dynamic_pointer_cast<monero_output_wallet>(*iter);
+      if (query.meets_criteria(input_wallet.get())) {
+        inputs.push_back(input_wallet);
+        iter++;
+      } else {
+        iter = m_inputs.erase(iter);
+      }
+    }
+    return inputs;
   }
 
   std::vector<std::shared_ptr<monero_output_wallet>> monero_tx_wallet::get_outputs_wallet() const {

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -297,9 +297,14 @@ namespace monero {
     std::shared_ptr<monero_tx_wallet> copy(const std::shared_ptr<monero_tx_wallet>& src, const std::shared_ptr<monero_tx_wallet>& tgt) const;
     void merge(const std::shared_ptr<monero_tx>& self, const std::shared_ptr<monero_tx>& other);
     void merge(const std::shared_ptr<monero_tx_wallet>& self, const std::shared_ptr<monero_tx_wallet>& other);
+    uint64_t get_incoming_amount() const;
+    uint64_t get_outgoing_amount() const;
     std::vector<std::shared_ptr<monero_transfer>> get_transfers() const;
     std::vector<std::shared_ptr<monero_transfer>> get_transfers(const monero_transfer_query& query) const;
     std::vector<std::shared_ptr<monero_transfer>> filter_transfers(const monero_transfer_query& query);
+    std::vector<std::shared_ptr<monero_output_wallet>> get_inputs_wallet() const;
+    std::vector<std::shared_ptr<monero_output_wallet>> get_inputs_wallet(const monero_output_query& query) const;
+    std::vector<std::shared_ptr<monero_output_wallet>> filter_inputs_wallet(const monero_output_query& query);
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs_wallet() const;
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs_wallet(const monero_output_query& query) const;
     std::vector<std::shared_ptr<monero_output_wallet>> filter_outputs_wallet(const monero_output_query& query);


### PR DESCRIPTION
moving [monero-python's MoneroTxWallet external utilities bindings](https://github.com/everoddandeven/monero-python/blob/main/src/cpp/wallet/py_monero_wallet_bindings.cpp#L301)

* add get_inputs_wallet
* add filter_inputs_wallet
* add get_incoming_amount
* add get_outgoing_amount