### PR TITLE
daemon rpc: implement missing methods

### DIFF
--- a/src/daemon/monero_daemon.h
+++ b/src/daemon/monero_daemon.h
@@ -256,14 +256,24 @@ namespace monero {
     /**
      * Get blocks by hash.
      * 
-     * @param block_hashes are array of hashes; first 10 blocks hash goes sequential,
+     * @param block_hashes is a short chain history; first 10 blocks hash goes sequential,
      *        next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on,
      *        and the last one is always genesis block
-     * @param start_height is the start height to get blocks by hash
-     * @param prune specifies if returned blocks should be pruned (defaults to false)  // TODO: test default
-     * @return the retrieved blocks
+     * @param start_height is the start height to resume from; when non-zero, daemon skips the
+     *        search to find the last block and is used as-is, ignoring block_hashes — except when
+     *        block_hashes[0] already matches the daemon's tip, which short-circuits to an empty
+     *        result (see @return) before start_height is ever consulted
+     * @param prune specifies if returned blocks should be pruned (defaults to false)
+     * @param max_block_count caps how many blocks the daemon returns in one call (0 leaves it to
+     *        the daemon's own default limit); use this to chunk large ranges instead of taking
+     *        whatever the daemon hands back
+     * @return the retrieved blocks plus the daemon's current chain height; the blocks are not a
+     *        lookup of block_hashes, so their heights won't line up with block_hashes 1:1; the range
+     *        starts at and includes the resume point (the common block found, or start_height itself
+     *        when non-zero), not the block after it; if block_hashes[0] already matches the daemon's
+     *        tip, an empty block list comes back (this noop check runs before start_height is consulted)
      */
-    virtual std::vector<std::shared_ptr<monero_block>> get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune) {
+    virtual std::shared_ptr<monero_get_blocks_by_hash_result> get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune, uint64_t max_block_count = 0) {
       throw std::runtime_error("monero_daemon::get_blocks_by_hash(): not supported");
     }
 
@@ -312,14 +322,16 @@ namespace monero {
 
     /**
      * Get block hashes as a binary request to the daemon.
-     * 
-     * @param block_hashes specify block hashes to fetch; first 10 blocks hash goes
-     *        sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64
-     *        and so on, and the last one is always genesis block
-     * @param start_height is the starting height of block hashes to return
-     * @return the requested block hashes
+     *
+     * @param block_hashes is a short chain history; first 10 blocks hash goes sequential,
+     *        next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on,
+     *        and the last one is always genesis block which is required, or the request fails.
+     * @return the requested hashes plus their start height and the daemon's current chain height;
+     *        the hash range starts at and includes the last one the daemon has in common with
+     *        block_hashes (not the one after it); if block_hashes[0] already matches the daemon's tip,
+     *        exactly one hash (the tip itself) comes back
      */
-    virtual std::vector<std::string> get_block_hashes(const std::vector<std::string>& block_hashes, uint64_t start_height) {
+    virtual std::shared_ptr<monero_get_block_hashes_result> get_block_hashes(const std::vector<std::string>& block_hashes) {
       throw std::runtime_error("monero_daemon::get_block_hashes(): not supported");
     }
 

--- a/src/daemon/monero_daemon_model.cpp
+++ b/src/daemon/monero_daemon_model.cpp
@@ -1710,4 +1710,58 @@ namespace monero {
     return root;
   }
 
+  // --------------------------- MONERO BLOCKS BY HASH RESULT ---------------------------
+
+  void monero_get_blocks_by_hash_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_blocks_by_hash_result>& result) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      // note: m_blocks is not round-tripped here; monero_block has no from_property_tree of its own yet
+      if (key == std::string("currentHeight")) result->m_current_height = it->second.get_value<uint64_t>();
+    }
+  }
+
+  rapidjson::Value monero_get_blocks_by_hash_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
+    // create root
+    rapidjson::Value root(rapidjson::kObjectType);
+
+    // set number values
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    if (m_current_height != boost::none) monero_utils::add_json_member("currentHeight", m_current_height.get(), allocator, root, value_num);
+
+    // set sub-arrays
+    if (!m_blocks.empty()) root.AddMember("blocks", monero_utils::to_rapidjson_val(allocator, m_blocks), allocator);
+
+    // return root
+    return root;
+  }
+
+  // --------------------------- MONERO BLOCK HASHES RESULT ---------------------------
+
+  void monero_get_block_hashes_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_block_hashes_result>& result) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("hashes")) {
+        for (const auto& child : it->second) result->m_hashes.push_back(child.second.data());
+      }
+      else if (key == std::string("startHeight")) result->m_start_height = it->second.get_value<uint64_t>();
+      else if (key == std::string("currentHeight")) result->m_current_height = it->second.get_value<uint64_t>();
+    }
+  }
+
+  rapidjson::Value monero_get_block_hashes_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
+    // create root
+    rapidjson::Value root(rapidjson::kObjectType);
+
+    // set number values
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    if (m_start_height != boost::none) monero_utils::add_json_member("startHeight", m_start_height.get(), allocator, root, value_num);
+    if (m_current_height != boost::none) monero_utils::add_json_member("currentHeight", m_current_height.get(), allocator, root, value_num);
+
+    // set sub-arrays
+    if (!m_hashes.empty()) root.AddMember("hashes", monero_utils::to_rapidjson_val(allocator, m_hashes), allocator);
+
+    // return root
+    return root;
+  }
+
 }

--- a/src/daemon/monero_daemon_model.h
+++ b/src/daemon/monero_daemon_model.h
@@ -699,4 +699,27 @@ namespace monero {
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
+  /**
+   * Models the result of getting blocks by hash.
+   */
+  struct monero_get_blocks_by_hash_result : public serializable_struct {
+    std::vector<std::shared_ptr<monero_block>> m_blocks;
+    boost::optional<uint64_t> m_current_height; // the daemon's chain height at request time
+
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_blocks_by_hash_result>& result);
+    rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+  };
+
+  /**
+   * Models the result of getting block hashes.
+   */
+  struct monero_get_block_hashes_result : public serializable_struct {
+    std::vector<std::string> m_hashes;
+    boost::optional<uint64_t> m_start_height; // height of first hash in m_hashes
+    boost::optional<uint64_t> m_current_height; // the daemon's chain height at request time
+
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_block_hashes_result>& result);
+    rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+  };
+
 }

--- a/src/daemon/monero_daemon_rpc.cpp
+++ b/src/daemon/monero_daemon_rpc.cpp
@@ -354,8 +354,17 @@ namespace monero {
     return found->second;
   }
 
-  std::vector<std::shared_ptr<monero_block>> monero_daemon_rpc::get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune) {
-    throw monero_error("monero_daemon_rpc::get_blocks_by_hash(): not implemented");
+  std::shared_ptr<monero_get_blocks_by_hash_result> monero_daemon_rpc::get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune, uint64_t max_block_count) {
+    monero_get_blocks_by_hash_request request(block_hashes, start_height, prune, max_block_count);
+    auto response = m_rpc->send_binary_request(request);
+    if (response.m_binary == boost::none) throw monero_error("Invalid Monero Binary response");
+    boost::property_tree::ptree node;
+    monero_utils::binary_blocks_fast_to_property_tree(response.m_binary.get(), node);
+    check_response_status(node);
+
+    auto result = std::make_shared<monero_get_blocks_by_hash_result>();
+    deserialize_get_blocks_by_hash_result(node, result);
+    return result;
   }
 
   std::shared_ptr<monero_block> monero_daemon_rpc::get_block_by_height(uint64_t height) {
@@ -457,8 +466,13 @@ namespace monero {
     return std::vector<std::shared_ptr<monero_block>>();
   }
 
-  std::vector<std::string> monero_daemon_rpc::get_block_hashes(const std::vector<std::string>& block_hashes, uint64_t start_height) {
-    throw monero_error("monero_daemon_rpc::get_block_hashes(): not implemented");
+  std::shared_ptr<monero_get_block_hashes_result> monero_daemon_rpc::get_block_hashes(const std::vector<std::string>& block_hashes) {
+    monero_get_block_hashes_request request(block_hashes);
+    auto response = m_rpc->send_binary_request(request);
+    if (response.m_binary == boost::none) throw monero_error("Invalid Monero Binary response");
+    auto result = std::make_shared<monero_get_block_hashes_result>();
+    deserialize_block_hashes(response.m_binary.get(), result);
+    return result;
   }
 
   std::vector<std::shared_ptr<monero_tx>> monero_daemon_rpc::get_txs(const std::vector<std::string>& tx_hashes, bool prune) {

--- a/src/daemon/monero_daemon_rpc.h
+++ b/src/daemon/monero_daemon_rpc.h
@@ -117,12 +117,12 @@ namespace monero {
     std::shared_ptr<monero_block_header> get_block_header_by_height(uint64_t height) override;
     std::vector<std::shared_ptr<monero_block_header>> get_block_headers_by_range(uint64_t start_height, uint64_t end_height) override;
     std::shared_ptr<monero_block> get_block_by_hash(const std::string& hash) override;
-    std::vector<std::shared_ptr<monero_block>> get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune) override;
+    std::shared_ptr<monero_get_blocks_by_hash_result> get_blocks_by_hash(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune, uint64_t max_block_count = 0) override;
     std::shared_ptr<monero_block> get_block_by_height(uint64_t height) override;
     std::vector<std::shared_ptr<monero_block>> get_blocks_by_height(const std::vector<uint64_t>& heights) override;
     std::vector<std::shared_ptr<monero_block>> get_blocks_by_range(boost::optional<uint64_t> start_height, boost::optional<uint64_t> end_height) override;
     std::vector<std::shared_ptr<monero_block>> get_blocks_by_range_chunked(boost::optional<uint64_t> start_height, boost::optional<uint64_t> end_height, boost::optional<uint64_t> max_chunk_size) override;
-    std::vector<std::string> get_block_hashes(const std::vector<std::string>& block_hashes, uint64_t start_height) override;
+    std::shared_ptr<monero_get_block_hashes_result> get_block_hashes(const std::vector<std::string>& block_hashes) override;
     std::vector<std::shared_ptr<monero_tx>> get_txs(const std::vector<std::string>& tx_hashes, bool prune = false) override;
     std::vector<std::string> get_tx_hexes(const std::vector<std::string>& tx_hashes, bool prune = false) override;
     std::shared_ptr<monero_miner_tx_sum> get_miner_tx_sum(uint64_t height, uint64_t num_blocks) override;

--- a/src/daemon/monero_daemon_rpc_model.cpp
+++ b/src/daemon/monero_daemon_rpc_model.cpp
@@ -60,6 +60,22 @@
 
 namespace monero {
 
+  // ----------------------- INTERNAL PRIVATE HELPERS -----------------------
+
+  namespace {
+    // used by monero_get_blocks_by_hash_request and monero_get_block_hashes_request
+    std::string block_hashes_to_blob(const std::vector<std::string>& block_hashes) {
+      // concatenate raw block_hashes encoded in a single blob
+      std::string blob;
+      for (const std::string& hash : block_hashes) {
+        std::string raw_hash;
+        if (!epee::string_tools::parse_hexstr_to_binbuff(hash, raw_hash) || raw_hash.size() != sizeof(crypto::hash)) throw monero_error("Invalid block hash: " + hash);
+        blob += raw_hash;
+      }
+      return blob;
+    }
+  }
+
   // --------------------------- MONERO RPC BAN ---------------------------
 
   monero_rpc_ban::monero_rpc_ban(const std::shared_ptr<monero_ban> &ban) {
@@ -100,6 +116,39 @@ namespace monero {
   rapidjson::Value monero_get_blocks_by_height_request::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     rapidjson::Value root(rapidjson::kObjectType);
     if (!m_heights.empty()) root.AddMember("heights", monero_utils::to_rapidjson_val(allocator, m_heights), allocator);
+    return root;
+  }
+
+  // --------------------------- MONERO GET BLOCKS BY HASH REQUEST ---------------------------
+
+  rapidjson::Value monero_get_blocks_by_hash_request::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
+    rapidjson::Value root(rapidjson::kObjectType);
+
+    rapidjson::Value value_str(rapidjson::kStringType);
+    monero_utils::add_json_member("block_ids", block_hashes_to_blob(m_block_hashes), allocator, root, value_str);
+
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    monero_utils::add_json_member("start_height", m_start_height, allocator, root, value_num);
+    if (m_max_block_count > 0) monero_utils::add_json_member("max_block_count", m_max_block_count, allocator, root, value_num);
+
+    monero_utils::add_json_member("prune", m_prune, allocator, root);
+
+    return root;
+  }
+
+  // --------------------------- MONERO GET BLOCK HASHES REQUEST ---------------------------
+
+  rapidjson::Value monero_get_block_hashes_request::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
+    rapidjson::Value root(rapidjson::kObjectType);
+
+    rapidjson::Value value_str(rapidjson::kStringType);
+    monero_utils::add_json_member("block_ids", block_hashes_to_blob(m_block_hashes), allocator, root, value_str);
+
+    // start_height is a required field on the wire but ignored by monerod for get_hashes.bin
+    // so it's sent as a fixed 0 rather than exposed here as a dead parameter.
+    rapidjson::Value value_num(rapidjson::kNumberType);
+    monero_utils::add_json_member("start_height", (uint64_t)0, allocator, root, value_num);
+
     return root;
   }
 
@@ -1011,6 +1060,27 @@ namespace monero {
         }
       }
     }
+  }
+
+  void deserialize_get_blocks_by_hash_result(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_blocks_by_hash_result>& result) {
+    // the daemon reports its own resume point, so the returned blocks are sequential from there
+    uint64_t start_height = node.get<uint64_t>("start_height");
+    size_t num_blocks = node.get_child("blocks").size();
+    std::vector<uint64_t> heights;
+    heights.reserve(num_blocks);
+    for (size_t i = 0; i < num_blocks; i++) heights.push_back(start_height + i);
+
+    deserialize_blocks(node, heights, result->m_blocks);
+    result->m_current_height = node.get<uint64_t>("current_height");
+  }
+
+  void deserialize_block_hashes(const std::string& bin, const std::shared_ptr<monero_get_block_hashes_result>& result) {
+    cryptonote::COMMAND_RPC_GET_HASHES_FAST::response resp_struct;
+    if (!epee::serialization::load_t_from_binary(resp_struct, bin)) throw monero_error("Failed to parse get_hashes.bin response");
+    if (resp_struct.status != CORE_RPC_STATUS_OK) throw monero_error("Failed to get block hashes from daemon: " + normalize_daemon_rpc_status(resp_struct.status));
+    result->m_start_height = resp_struct.start_height;
+    result->m_current_height = resp_struct.current_height;
+    for (const crypto::hash& hash : resp_struct.m_block_ids) result->m_hashes.push_back(epee::string_tools::pod_to_hex(hash));
   }
 
   void deserialize_alt_block_hashes(const boost::property_tree::ptree& node, std::vector<std::string>& block_hashes) {

--- a/src/daemon/monero_daemon_rpc_model.h
+++ b/src/daemon/monero_daemon_rpc_model.h
@@ -84,6 +84,31 @@ namespace monero {
   };
 
   /**
+   * Models paramaters for monerod-rpc `/get_blocks.bin` method (fast sync by short chain history).
+   */
+  struct monero_get_blocks_by_hash_request : public monero_rpc_request {
+    std::vector<std::string> m_block_hashes;
+    uint64_t m_start_height;
+    bool m_prune;
+    uint64_t m_max_block_count;
+
+    monero_get_blocks_by_hash_request(const std::vector<std::string>& block_hashes, uint64_t start_height, bool prune, uint64_t max_block_count = 0): m_block_hashes(block_hashes), m_start_height(start_height), m_prune(prune), m_max_block_count(max_block_count) { m_method = "get_blocks.bin"; }
+
+    rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+  };
+
+  /**
+   * Models paramaters for monerod-rpc `/get_hashes.bin` method.
+   */
+  struct monero_get_block_hashes_request : public monero_rpc_request {
+    std::vector<std::string> m_block_hashes;
+
+    monero_get_block_hashes_request(const std::vector<std::string>& block_hashes): m_block_hashes(block_hashes) { m_method = "get_hashes.bin"; }
+
+    rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+  };
+
+  /**
    * Models paramaters for monerod-rpc `/get_o_indexes.bin` method.
    */
   struct monero_get_output_indices_request : public monero_rpc_request {
@@ -372,6 +397,8 @@ namespace monero {
   void deserialize_block_headers(const boost::property_tree::ptree& node, std::vector<std::shared_ptr<monero_block_header>>& headers);
   void deserialize_block(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block>& block, bool is_nested = false);
   void deserialize_blocks(const boost::property_tree::ptree& node, const std::vector<uint64_t>& heights, std::vector<std::shared_ptr<monero_block>>& blocks);
+  void deserialize_get_blocks_by_hash_result(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_blocks_by_hash_result>& result);
+  void deserialize_block_hashes(const std::string& bin, const std::shared_ptr<monero_get_block_hashes_result>& result);
   void deserialize_alt_block_hashes(const boost::property_tree::ptree& node, std::vector<std::string>& block_hashes);
   void deserialize_txs(const boost::property_tree::ptree& node, std::vector<std::shared_ptr<monero_tx>>& txs);
   void deserialize_tx_hashes(const boost::property_tree::ptree& node, std::vector<std::string>& tx_hashes);

--- a/src/utils/monero_utils.cpp
+++ b/src/utils/monero_utils.cpp
@@ -63,6 +63,116 @@
 using namespace cryptonote;
 using namespace monero_utils;
 
+// ----------------------- INTERNAL PRIVATE HELPERS -----------------------
+
+namespace {
+  // shared by monero_utils::binary_blocks_to_json() and monero_utils::binary_blocks_fast_to_json()
+  void add_blocks_and_txs_to_ptree(const std::vector<cryptonote::block_complete_entry>& blocks, boost::property_tree::ptree& root) {
+    boost::property_tree::ptree blocksNode; // array of block strings
+    boost::property_tree::ptree txsNodes;   // array of txs per block (array of array)
+    boost::property_tree::ptree hashesNode; // array of block hashes
+    for (int blockIdx = 0; blockIdx < blocks.size(); blockIdx++) {
+
+      // parse and validate block
+      cryptonote::block block;
+      if (cryptonote::parse_and_validate_block_from_blob(blocks[blockIdx].block, block)) {
+
+        // add block node to blocks node
+        boost::property_tree::ptree blockNode;
+        blockNode.put("", cryptonote::obj_to_json_str(block));  // TODO: no pretty print
+        blocksNode.push_back(std::make_pair("", blockNode));
+
+        // compute block's hash and add to hashes node in parallel
+        boost::property_tree::ptree hashNode;
+        hashNode.put("", epee::string_tools::pod_to_hex(cryptonote::get_block_hash(block)));
+        hashesNode.push_back(std::make_pair("", hashNode));
+      } else {
+        throw std::runtime_error("failed to parse block blob at index " + std::to_string(blockIdx));
+      }
+
+      // parse and validate txs: a pruned blob only has the base (no prunable section), so it
+      // must go through the base-only parser or the full parser fails on every non-miner tx
+      boost::property_tree::ptree txs_node;
+      for (int txIdx = 0; txIdx < blocks[blockIdx].txs.size(); txIdx++) {
+        cryptonote::transaction tx;
+        bool parsed = blocks[blockIdx].pruned
+          ? cryptonote::parse_and_validate_tx_base_from_blob(blocks[blockIdx].txs[txIdx].blob, tx)
+          : cryptonote::parse_and_validate_tx_from_blob(blocks[blockIdx].txs[txIdx].blob, tx);
+        if (parsed) {
+
+          // add tx node to txs node
+          boost::property_tree::ptree txNode;
+          //MTRACE("PRUNED:\n" << monero_utils::get_pruned_tx_json(tx));
+          txNode.put("", monero_utils::get_pruned_tx_json(tx)); // TODO: no pretty print
+          txs_node.push_back(std::make_pair("", txNode));
+        } else {
+          throw std::runtime_error("failed to parse tx blob at index " + std::to_string(txIdx));
+        }
+      }
+      txsNodes.push_back(std::make_pair("", txs_node)); // array of array of transactions, one array per block
+    }
+    root.add_child("blocks", blocksNode);
+    root.add_child("txs", txsNodes);
+    root.add_child("block_hashes", hashesNode);
+  }
+
+  // shared by monero_utils::binary_blocks_to_property_tree() and monero_utils::binary_blocks_fast_to_property_tree()
+  void bin_blocks_to_property_tree(const std::string &bin, boost::property_tree::ptree &node, bool is_fast) {
+    std::string response_json;
+    if (is_fast) monero_utils::binary_blocks_fast_to_json(bin, response_json);
+    else monero_utils::binary_blocks_to_json(bin, response_json);
+    std::istringstream iss(response_json);
+    boost::property_tree::read_json(iss, node);
+
+    auto blocks = node.get_child("blocks");
+    auto block_hashes = node.get_child("block_hashes"); // parallel to "blocks", see add_blocks_and_txs_to_ptree()
+    boost::property_tree::ptree parsed_blocks;
+
+    auto hash_it = block_hashes.begin();
+    for (auto &entry : blocks) {
+      const std::string &block_str = entry.second.get_value<std::string>();
+      boost::property_tree::ptree block_node;
+      gen_utils::deserialize(block_str, block_node);
+      if (hash_it != block_hashes.end()) {
+        block_node.put("hash", hash_it->second.get_value<std::string>());
+        ++hash_it;
+      }
+      parsed_blocks.push_back(std::make_pair("", block_node));
+    }
+
+    node.put_child("blocks", parsed_blocks);
+    node.erase("block_hashes"); // merged into each block above
+
+    auto txs = node.get_child("txs");
+    boost::property_tree::ptree all_txs;
+
+    for (auto &rpc_txs_entry : txs) {
+      boost::property_tree::ptree txs_for_block;
+      const auto &rpc_txs = rpc_txs_entry.second;
+
+      if (!rpc_txs.empty() || !rpc_txs.data().empty()) {
+        for (auto &tx_entry : rpc_txs) {
+          std::string tx_str = tx_entry.second.get_value<std::string>();
+
+          auto pos = tx_str.find(',');
+          if (pos != std::string::npos) {
+            tx_str.replace(pos, 1, "{");
+            tx_str += "}";
+          }
+
+          boost::property_tree::ptree tx_node;
+          gen_utils::deserialize(tx_str, tx_node);
+          txs_for_block.push_back(std::make_pair("", tx_node));
+        }
+      }
+
+      all_txs.push_back(std::make_pair("", txs_for_block));
+    }
+
+    node.put_child("txs", all_txs);
+  }
+}
+
 void monero_utils::set_log_level(int level) {
   mlog_set_log_level(level);
 }
@@ -248,47 +358,33 @@ void monero_utils::binary_blocks_to_json(const std::string &bin, std::string &js
 
   // load binary rpc response to struct
   cryptonote::COMMAND_RPC_GET_BLOCKS_BY_HEIGHT::response resp_struct;
-  epee::serialization::load_t_from_binary(resp_struct, bin);
+  if (!epee::serialization::load_t_from_binary(resp_struct, bin)) throw std::runtime_error("failed to parse get_blocks_by_height.bin response");
 
   // build property tree from deserialized blocks and transactions
   boost::property_tree::ptree root;
-  boost::property_tree::ptree blocksNode; // array of block strings
-  boost::property_tree::ptree txsNodes;   // array of txs per block (array of array)
-  for (int blockIdx = 0; blockIdx < resp_struct.blocks.size(); blockIdx++) {
-
-    // parse and validate block
-    cryptonote::block block;
-    if (cryptonote::parse_and_validate_block_from_blob(resp_struct.blocks[blockIdx].block, block)) {
-
-      // add block node to blocks node
-      boost::property_tree::ptree blockNode;
-      blockNode.put("", cryptonote::obj_to_json_str(block));  // TODO: no pretty print
-      blocksNode.push_back(std::make_pair("", blockNode));
-    } else {
-      throw std::runtime_error("failed to parse block blob at index " + std::to_string(blockIdx));
-    }
-
-    // parse and validate txs
-    boost::property_tree::ptree txs_node;
-    for (int txIdx = 0; txIdx < resp_struct.blocks[blockIdx].txs.size(); txIdx++) {
-      cryptonote::transaction tx;
-      if (cryptonote::parse_and_validate_tx_from_blob(resp_struct.blocks[blockIdx].txs[txIdx].blob, tx)) {
-
-        // add tx node to txs node
-        boost::property_tree::ptree txNode;
-        //MTRACE("PRUNED:\n" << monero_utils::get_pruned_tx_json(tx));
-        txNode.put("", monero_utils::get_pruned_tx_json(tx)); // TODO: no pretty print
-        txs_node.push_back(std::make_pair("", txNode));
-      } else {
-        throw std::runtime_error("failed to parse tx blob at index " + std::to_string(txIdx));
-      }
-    }
-    txsNodes.push_back(std::make_pair("", txs_node)); // array of array of transactions, one array per block
-  }
-  root.add_child("blocks", blocksNode);
-  root.add_child("txs", txsNodes);
+  add_blocks_and_txs_to_ptree(resp_struct.blocks, root);
   root.put("status", resp_struct.status);
   root.put("untrusted", resp_struct.untrusted); // TODO: loss of ints and bools
+
+  // convert root to string // TODO: common utility with serial_bridge
+  std::stringstream ss;
+  boost::property_tree::write_json(ss, root, false/*pretty*/);
+  json = ss.str();
+}
+
+void monero_utils::binary_blocks_fast_to_json(const std::string &bin, std::string &json) {
+
+  // load binary rpc response to struct
+  cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response resp_struct;
+  if (!epee::serialization::load_t_from_binary(resp_struct, bin)) throw std::runtime_error("failed to parse get_blocks.bin response");
+
+  // build property tree from deserialized blocks and transactions
+  boost::property_tree::ptree root;
+  add_blocks_and_txs_to_ptree(resp_struct.blocks, root);
+  root.put("status", resp_struct.status);
+  root.put("untrusted", resp_struct.untrusted); // TODO: loss of ints and bools
+  root.put("start_height", resp_struct.start_height);
+  root.put("current_height", resp_struct.current_height);
 
   // convert root to string // TODO: common utility with serial_bridge
   std::stringstream ss;
@@ -448,50 +544,11 @@ std::shared_ptr<monero_tx> monero_utils::cn_tx_to_tx(const cryptonote::transacti
 }
 
 void monero_utils::binary_blocks_to_property_tree(const std::string &bin, boost::property_tree::ptree &node) {
-  std::string response_json;
-  monero_utils::binary_blocks_to_json(bin, response_json);
-  std::istringstream iss(response_json);
-  boost::property_tree::read_json(iss, node);
+  bin_blocks_to_property_tree(bin, node, false);
+}
 
-  auto blocks = node.get_child("blocks");
-  boost::property_tree::ptree parsed_blocks;
-
-  for (auto &entry : blocks) {
-    const std::string &block_str = entry.second.get_value<std::string>();
-    boost::property_tree::ptree block_node;
-    gen_utils::deserialize(block_str, block_node);
-    parsed_blocks.push_back(std::make_pair("", block_node));
-  }
-
-  node.put_child("blocks", parsed_blocks);
-
-  auto txs = node.get_child("txs");
-  boost::property_tree::ptree all_txs;
-
-  for (auto &rpc_txs_entry : txs) {
-    boost::property_tree::ptree txs_for_block;
-    const auto &rpc_txs = rpc_txs_entry.second;
-
-    if (!rpc_txs.empty() || !rpc_txs.data().empty()) {
-      for (auto &tx_entry : rpc_txs) {
-        std::string tx_str = tx_entry.second.get_value<std::string>();
-
-        auto pos = tx_str.find(',');
-        if (pos != std::string::npos) {
-          tx_str.replace(pos, 1, "{");
-          tx_str += "}";
-        }
-
-        boost::property_tree::ptree tx_node;
-        gen_utils::deserialize(tx_str, tx_node);
-        txs_for_block.push_back(std::make_pair("", tx_node));
-      }
-    }
-
-    all_txs.push_back(std::make_pair("", txs_for_block));
-  }
-
-  node.put_child("txs", all_txs);
+void monero_utils::binary_blocks_fast_to_property_tree(const std::string &bin, boost::property_tree::ptree &node) {
+  bin_blocks_to_property_tree(bin, node, true);
 }
 
 void monero_utils::merge_tx(const std::shared_ptr<monero_tx_wallet>& tx, std::map<std::string, std::shared_ptr<monero_tx_wallet>>& tx_map, std::map<uint64_t, std::shared_ptr<monero_block>>& block_map) {

--- a/src/utils/monero_utils.h
+++ b/src/utils/monero_utils.h
@@ -96,6 +96,7 @@ namespace monero_utils
   void json_to_binary(const std::string &json, std::string &bin);
   void binary_to_json(const std::string &bin, std::string &json);
   void binary_blocks_to_json(const std::string &bin, std::string &json);
+  void binary_blocks_fast_to_json(const std::string &bin, std::string &json);
   uint64_t xmr_to_atomic_units(double amount_xmr);
   double atomic_units_to_xmr(uint64_t amount_atomic_units);
 
@@ -182,6 +183,7 @@ namespace monero_utils
   }
 
   void binary_blocks_to_property_tree(const std::string &bin, boost::property_tree::ptree &node);
+  void binary_blocks_fast_to_property_tree(const std::string &bin, boost::property_tree::ptree &node);
 
   /**
     * Merges a transaction into a unique set of transactions.


### PR DESCRIPTION
* Implement monero_daemon_rpc::get_blocks_by_hash and improve documentation
* Implement monero_daemon_rpc::get_block_hashes and improve documentation
* Implement monero_utils::binary_blocks_fast_to_json
* implement  monero_utils::binary_blocks_fast_to_property_tree
* Add guard against invalid bin in monero_utils::binary_blocks_to_json instead of returning no blocks