### PR TITLE
data model: implement missing from property tree

### DIFF
--- a/src/daemon/monero_daemon_model.cpp
+++ b/src/daemon/monero_daemon_model.cpp
@@ -136,6 +136,19 @@ namespace monero {
     return root;
   }
 
+  void ssl_options::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<ssl_options>& options) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("sslPrivateKeyPath")) options->m_ssl_private_key_path = it->second.data();
+      else if (key == std::string("sslCertificatePath")) options->m_ssl_certificate_path = it->second.data();
+      else if (key == std::string("sslCaFile")) options->m_ssl_ca_file = it->second.data();
+      else if (key == std::string("sslAllowedFingerprints")) {
+        for (const auto& child : it->second) options->m_ssl_allowed_fingerprints.push_back(child.second.data());
+      }
+      else if (key == std::string("sslAllowAnyCert")) options->m_ssl_allow_any_cert = it->second.get_value<bool>();
+    }
+  }
+
   // ------------------------- MONERO BLOCK HEADER ----------------------------
 
   rapidjson::Value monero_block_header::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -173,6 +186,32 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_block_header::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block_header>& header) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("hash")) header->m_hash = it->second.data();
+      else if (key == std::string("height")) header->m_height = it->second.get_value<uint64_t>();
+      else if (key == std::string("timestamp")) header->m_timestamp = it->second.get_value<uint64_t>();
+      else if (key == std::string("size")) header->m_size = it->second.get_value<uint64_t>();
+      else if (key == std::string("weight")) header->m_weight = it->second.get_value<uint64_t>();
+      else if (key == std::string("longTermWeight")) header->m_long_term_weight = it->second.get_value<uint64_t>();
+      else if (key == std::string("depth")) header->m_depth = it->second.get_value<uint64_t>();
+      else if (key == std::string("difficultyLow")) header->m_difficulty_low = it->second.get_value<uint64_t>();
+      else if (key == std::string("difficultyHigh")) header->m_difficulty_high = it->second.get_value<uint64_t>();
+      else if (key == std::string("cumulativeDifficultyLow")) header->m_cumulative_difficulty_low = it->second.get_value<uint64_t>();
+      else if (key == std::string("cumulativeDifficultyHigh")) header->m_cumulative_difficulty_high = it->second.get_value<uint64_t>();
+      else if (key == std::string("majorVersion")) header->m_major_version = it->second.get_value<uint32_t>();
+      else if (key == std::string("minorVersion")) header->m_minor_version = it->second.get_value<uint32_t>();
+      else if (key == std::string("nonce")) header->m_nonce = it->second.get_value<uint32_t>();
+      else if (key == std::string("minerTxHash")) header->m_miner_tx_hash = it->second.data();
+      else if (key == std::string("numTxs")) header->m_num_txs = it->second.get_value<uint32_t>();
+      else if (key == std::string("orphanStatus")) header->m_orphan_status = it->second.get_value<bool>();
+      else if (key == std::string("prevHash")) header->m_prev_hash = it->second.data();
+      else if (key == std::string("reward")) header->m_reward = it->second.get_value<uint64_t>();
+      else if (key == std::string("powHash")) header->m_pow_hash = it->second.data();
+    }
   }
 
   std::shared_ptr<monero_block_header> monero_block_header::copy(const std::shared_ptr<monero_block_header>& src, const std::shared_ptr<monero_block_header>& tgt) const {
@@ -246,6 +285,33 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_block::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block>& block) {
+    monero_block_header::from_property_tree(node, block);
+
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("hex")) block->m_hex = it->second.data();
+      else if (key == std::string("txHashes")) {
+        for (const auto& child : it->second) block->m_tx_hashes.push_back(child.second.data());
+      }
+      else if (key == std::string("txs")) {
+        for (const auto& child : it->second) {
+          auto tx = std::make_shared<monero_tx>();
+          monero_tx::from_property_tree(child.second, tx);
+          tx->m_block = block;
+          block->m_txs.push_back(tx);
+        }
+      }
+      else if (key == std::string("minerTx")) {
+        auto tx = std::make_shared<monero_tx>();
+        monero_tx::from_property_tree(it->second, tx);
+        tx->m_is_miner_tx = true;
+        tx->m_block = block;
+        block->m_miner_tx = tx;
+      }
+    }
   }
 
   std::shared_ptr<monero_block> monero_block::copy(const std::shared_ptr<monero_block>& src, const std::shared_ptr<monero_block>& tgt) const {

--- a/src/daemon/monero_daemon_model.h
+++ b/src/daemon/monero_daemon_model.h
@@ -98,6 +98,7 @@ namespace monero {
     boost::optional<bool> m_ssl_allow_any_cert;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<ssl_options>& options);
   };
 
   /**
@@ -177,6 +178,7 @@ namespace monero {
     boost::optional<std::string> m_pow_hash;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block_header>& header);
     std::shared_ptr<monero_block_header> copy(const std::shared_ptr<monero_block_header>& src, const std::shared_ptr<monero_block_header>& tgt) const;
     virtual void merge(const std::shared_ptr<monero_block_header>& self, const std::shared_ptr<monero_block_header>& other);
   };
@@ -191,6 +193,7 @@ namespace monero {
     std::vector<std::string> m_tx_hashes;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block>& block);
     std::shared_ptr<monero_block> copy(const std::shared_ptr<monero_block>& src, const std::shared_ptr<monero_block>& tgt) const;
     void merge(const std::shared_ptr<monero_block_header>& self, const std::shared_ptr<monero_block_header>& other);
     void merge(const std::shared_ptr<monero_block>& self, const std::shared_ptr<monero_block>& other);

--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -157,15 +157,7 @@ namespace monero {
     return root;
   }
 
-  std::shared_ptr<monero_wallet_config> monero_wallet_config::deserialize(const std::string& config_json) {
-
-    // deserialize config json to property node
-    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert config property tree to monero_wallet_config
-    std::shared_ptr<monero_wallet_config> config = std::make_shared<monero_wallet_config>();
+  void monero_wallet_config::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_wallet_config>& config) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
       if (key == std::string("path")) config->m_path = it->second.data();
@@ -192,7 +184,18 @@ namespace monero {
       else if (key == std::string("isMultisig")) config->m_is_multisig = it->second.get_value<bool>();
       else if (key == std::string("regtest")) config->m_regtest = it->second.get_value<bool>();
     }
+  }
 
+  std::shared_ptr<monero_wallet_config> monero_wallet_config::deserialize(const std::string& config_json) {
+
+    // deserialize config json to property node
+    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
+    boost::property_tree::ptree node;
+    boost::property_tree::read_json(iss, node);
+
+    // convert config property tree to monero_wallet_config
+    std::shared_ptr<monero_wallet_config> config = std::make_shared<monero_wallet_config>();
+    from_property_tree(node, config);
     return config;
   }
 
@@ -212,6 +215,14 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_sync_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_sync_result>& result) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("numBlocksFetched")) result->m_num_blocks_fetched = it->second.get_value<uint64_t>();
+      else if (key == std::string("receivedMoney")) result->m_received_money = it->second.get_value<bool>();
+    }
   }
 
   // -------------------------- MONERO ACCOUNT -----------------------------
@@ -949,6 +960,17 @@ namespace monero {
     return root;
   }
 
+  void monero_incoming_transfer::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_incoming_transfer>& transfer) {
+    monero_transfer::from_property_tree(node, transfer);
+
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("subaddressIndex")) transfer->m_subaddress_index = it->second.get_value<uint32_t>();
+      else if (key == std::string("numSuggestedConfirmations")) transfer->m_num_suggested_confirmations = it->second.get_value<uint64_t>();
+      else if (key == std::string("address")) transfer->m_address = it->second.data();
+    }
+  }
+
   std::shared_ptr<monero_incoming_transfer> monero_incoming_transfer::copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const {
     return copy(std::static_pointer_cast<monero_incoming_transfer>(src), std::static_pointer_cast<monero_incoming_transfer>(tgt));
   }
@@ -990,6 +1012,27 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_outgoing_transfer::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_outgoing_transfer>& transfer) {
+    monero_transfer::from_property_tree(node, transfer);
+
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("subaddressIndices")) {
+        for (const auto& child : it->second) transfer->m_subaddress_indices.push_back(child.second.get_value<uint32_t>());
+      }
+      else if (key == std::string("addresses")) {
+        for (const auto& child : it->second) transfer->m_addresses.push_back(child.second.data());
+      }
+      else if (key == std::string("destinations")) {
+        for (const auto& child : it->second) {
+          auto destination = std::make_shared<monero_destination>();
+          monero_destination::from_property_tree(child.second, destination);
+          transfer->m_destinations.push_back(destination);
+        }
+      }
+    }
   }
 
   std::shared_ptr<monero_outgoing_transfer> monero_outgoing_transfer::copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const {
@@ -1473,15 +1516,7 @@ namespace monero {
     return root;
   }
 
-  std::shared_ptr<monero_tx_config> monero_tx_config::deserialize(const std::string& config_json) {
-
-    // deserialize config json to property node
-    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert config property tree to monero_tx_config
-    std::shared_ptr<monero_tx_config> config = std::make_shared<monero_tx_config>();
+  void monero_tx_config::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_config>& config) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
       if (key == std::string("destinations")) {
@@ -1514,7 +1549,18 @@ namespace monero {
       else if (key == std::string("sweepEachSubaddress")) config->m_sweep_each_subaddress = it->second.get_value<bool>();
       else if (key == std::string("keyImage")) config->m_key_image = it->second.data();
     }
+  }
 
+  std::shared_ptr<monero_tx_config> monero_tx_config::deserialize(const std::string& config_json) {
+
+    // deserialize config json to property node
+    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
+    boost::property_tree::ptree node;
+    boost::property_tree::read_json(iss, node);
+
+    // convert config property tree to monero_tx_config
+    std::shared_ptr<monero_tx_config> config = std::make_shared<monero_tx_config>();
+    from_property_tree(node, config);
     return config;
   }
 
@@ -1576,15 +1622,7 @@ namespace monero {
     return root;
   }
 
-  std::shared_ptr<monero_key_image_export_result> monero_key_image_export_result::deserialize(const std::string& result_json) {
-
-    // deserialize json to property node
-    std::istringstream iss = result_json.empty() ? std::istringstream() : std::istringstream(result_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert property tree to export result
-    std::shared_ptr<monero_key_image_export_result> result = std::make_shared<monero_key_image_export_result>();
+  void monero_key_image_export_result::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_export_result>& result) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
       if (key == std::string("offset")) result->m_offset = it->second.get_value<uint64_t>();
@@ -1596,6 +1634,18 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_key_image_export_result> monero_key_image_export_result::deserialize(const std::string& result_json) {
+
+    // deserialize json to property node
+    std::istringstream iss = result_json.empty() ? std::istringstream() : std::istringstream(result_json);
+    boost::property_tree::ptree node;
+    boost::property_tree::read_json(iss, node);
+
+    // convert property tree to export result
+    std::shared_ptr<monero_key_image_export_result> result = std::make_shared<monero_key_image_export_result>();
+    from_property_tree(node, result);
     return result;
   }
 
@@ -1675,6 +1725,13 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_check::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check>& check) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("isGood")) check->m_is_good = it->second.get_value<bool>();
+    }
   }
 
   // --------------------------- MONERO CHECK TX ------------------------------
@@ -1936,6 +1993,15 @@ namespace monero {
 
     // return root
     return root;
+  }
+
+  void monero_decoded_address::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_decoded_address>& address) {
+    for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
+      std::string key = it->first;
+      if (key == std::string("address")) address->m_address = it->second.data();
+      else if (key == std::string("addressType")) address->m_address_type = static_cast<monero_address_type>(it->second.get_value<uint32_t>());
+      else if (key == std::string("networkType")) address->m_network_type = static_cast<monero_network_type>(it->second.get_value<uint32_t>());
+    }
   }
 
   // --------------------------- MONERO ACCOUNT TAG ---------------------------

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -88,6 +88,7 @@ namespace monero {
     monero_wallet_config(const monero_wallet_config& config);
     monero_wallet_config copy() const;
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_wallet_config>& config);
     static std::shared_ptr<monero_wallet_config> deserialize(const std::string& config_json);
   };
 
@@ -101,6 +102,7 @@ namespace monero {
     monero_sync_result(const uint64_t num_blocks_fetched, const bool received_money) : m_num_blocks_fetched(num_blocks_fetched), m_received_money(received_money) {}
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_sync_result>& result);
   };
 
   /**
@@ -185,6 +187,7 @@ namespace monero {
     boost::optional<uint64_t> m_num_suggested_confirmations;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_incoming_transfer>& transfer);
     std::shared_ptr<monero_incoming_transfer> copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const;
     std::shared_ptr<monero_incoming_transfer> copy(const std::shared_ptr<monero_incoming_transfer>& src, const std::shared_ptr<monero_incoming_transfer>& tgt) const;
     boost::optional<bool> is_incoming() const;
@@ -201,6 +204,7 @@ namespace monero {
     std::vector<std::shared_ptr<monero_destination>> m_destinations;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_outgoing_transfer>& transfer);
     std::shared_ptr<monero_outgoing_transfer> copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const;
     std::shared_ptr<monero_outgoing_transfer> copy(const std::shared_ptr<monero_outgoing_transfer>& src, const std::shared_ptr<monero_outgoing_transfer>& tgt) const;
     boost::optional<bool> is_incoming() const;
@@ -413,6 +417,7 @@ namespace monero {
     monero_tx_config(const monero_tx_config& config);
     monero_tx_config copy() const;
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_config>& config);
     static std::shared_ptr<monero_tx_config> deserialize(const std::string& config_json);
     std::vector<std::shared_ptr<monero_destination>> get_normalized_destinations() const;
   };
@@ -425,6 +430,7 @@ namespace monero {
     std::vector<std::shared_ptr<monero_key_image>> m_key_images;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_export_result>& result);
     static std::shared_ptr<monero_key_image_export_result> deserialize(const std::string& result_json);
   };
 
@@ -468,6 +474,7 @@ namespace monero {
     bool m_is_good;
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check>& check);
   };
 
   /**
@@ -586,9 +593,11 @@ namespace monero {
     monero_address_type m_address_type;
     monero_network_type m_network_type;
 
+    monero_decoded_address(): m_address_type(monero_address_type::PRIMARY_ADDRESS), m_network_type(monero_network_type::MAINNET) {}
     monero_decoded_address(const std::string& address, monero_address_type address_type, monero_network_type network_type);
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_decoded_address>& address);
   };
 
   /**


### PR DESCRIPTION
Useful to test the serialization/deserialization of these missing structures in the unit tests I implemented in monero-python for monero-cpp's data model bindings. I actually use this [template function](https://github.com/everoddandeven/monero-python/blob/main/src/cpp/py_monero_types.h#L67) in bindings to expose `deserialize` method for data model from JSON string. Wondering if that template function should be part of monero-cpp and use that for expose `deserialize` methods for all public data structure with `from_property_tree`.

* Implement ssl_options::from_property_tree
* Implement monero_block_header::from_property_tree
* Implement monero_block::from_property_tree
* Implement monero_wallet_config::from_property_tree and refactory monero_wallet_config::deserialize
* Implement monero_sync_result::from_property_tree
* Implement monero_incoming_transfer::from_property_tree
* Implement monero_outgoing_transfer::from_property_tree
* Implement monero_tx_config::from_property_tree and refactory monero_tx_config::deserialize
* Implement monero_key_image_export_result::from_property_tree and refactory monero_key_image_export_result::deserialize
* Implement monero_check::from_property_tree
* Implement monero_decoded_address::from_property_tree