### PR TITLE
data model: implement deserialize method

### DIFF
--- a/src/common/monero_rpc_connection.cpp
+++ b/src/common/monero_rpc_connection.cpp
@@ -424,8 +424,7 @@ namespace monero {
     else deserialize_rpc_response(result, response, uri, request.m_method.get());
   }
 
-  std::shared_ptr<monero_rpc_connection> monero_rpc_connection::from_property_tree(const boost::property_tree::ptree& node) {
-    std::shared_ptr<monero_rpc_connection> connection = std::make_shared<monero_rpc_connection>();
+  void monero_rpc_connection::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_rpc_connection>& connection) {
     for (boost::property_tree::ptree::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string key = it->first;
       if (key == std::string("uri")) connection->m_uri = it->second.data();
@@ -436,6 +435,10 @@ namespace monero {
       else if (key == std::string("priority")) connection->m_priority = it->second.get_value<int>();
       else if (key == std::string("timeoutMs")) connection->m_timeout_ms = it->second.get_value<uint32_t>();
     }
-    return connection;
   }
+
+  std::shared_ptr<monero_rpc_connection> monero_rpc_connection::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_rpc_connection>(json);
+  }
+
 }

--- a/src/common/monero_rpc_connection.h
+++ b/src/common/monero_rpc_connection.h
@@ -118,7 +118,8 @@ namespace monero {
     boost::optional<uint64_t> m_response_time;   // automatically set by calling check_connection()
     int m_priority;                              // priority relative to other connections where 1 is highest, then 2, etc, and 0 is lowest (default)
 
-    static std::shared_ptr<monero_rpc_connection> from_property_tree(const boost::property_tree::ptree& node);
+    static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_rpc_connection>& connection);
+    static std::shared_ptr<monero_rpc_connection> deserialize(const std::string& json);
 
     /**
      * Checks RPC connection priority order.

--- a/src/daemon/monero_daemon_model.cpp
+++ b/src/daemon/monero_daemon_model.cpp
@@ -117,6 +117,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_version> monero_version::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_version>(json);
+  }
+
   // --------------------------- SSL OPTIONS ---------------------------
 
   rapidjson::Value ssl_options::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -147,6 +151,10 @@ namespace monero {
       }
       else if (key == std::string("sslAllowAnyCert")) options->m_ssl_allow_any_cert = it->second.get_value<bool>();
     }
+  }
+
+  std::shared_ptr<ssl_options> ssl_options::deserialize(const std::string& json) {
+    return gen_utils::deserialize<ssl_options>(json);
   }
 
   // ------------------------- MONERO BLOCK HEADER ----------------------------
@@ -212,6 +220,10 @@ namespace monero {
       else if (key == std::string("reward")) header->m_reward = it->second.get_value<uint64_t>();
       else if (key == std::string("powHash")) header->m_pow_hash = it->second.data();
     }
+  }
+
+  std::shared_ptr<monero_block_header> monero_block_header::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_block_header>(json);
   }
 
   std::shared_ptr<monero_block_header> monero_block_header::copy(const std::shared_ptr<monero_block_header>& src, const std::shared_ptr<monero_block_header>& tgt) const {
@@ -312,6 +324,10 @@ namespace monero {
         block->m_miner_tx = tx;
       }
     }
+  }
+
+  std::shared_ptr<monero_block> monero_block::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_block>(json);
   }
 
   std::shared_ptr<monero_block> monero_block::copy(const std::shared_ptr<monero_block>& src, const std::shared_ptr<monero_block>& tgt) const {
@@ -499,6 +515,10 @@ namespace monero {
       else if (key == std::string("maxUsedBlockHash")) tx->m_max_used_block_hash = it->second.data();
       else if (key == std::string("signatures")) throw std::runtime_error("signatures deserialization not implemented");
     }
+  }
+
+  std::shared_ptr<monero_tx> monero_tx::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_tx>(json);
   }
 
   std::shared_ptr<monero_tx> monero_tx::copy(const std::shared_ptr<monero_tx>& src, const std::shared_ptr<monero_tx>& tgt) const {
@@ -690,6 +710,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_key_image> monero_key_image::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_key_image>(json);
+  }
+
   std::vector<std::shared_ptr<monero_key_image>> monero_key_image::deserialize_key_images(const std::string& key_images_json) {
 
     // deserialize json to property node
@@ -776,6 +800,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_output> monero_output::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_output>(json);
+  }
+
   std::shared_ptr<monero_output> monero_output::copy(const std::shared_ptr<monero_output>& src, const std::shared_ptr<monero_output>& tgt) const {
     if (this != src.get()) throw std::runtime_error("this != src");
     tgt->m_tx = src->m_tx;  // reference same parent tx by default
@@ -818,6 +846,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_rpc_payment_info> monero_rpc_payment_info::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_rpc_payment_info>(json);
+  }
+
   rapidjson::Value monero_rpc_payment_info::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -848,6 +880,10 @@ namespace monero {
       else if (key == std::string("length")) alt_chain->m_length = it->second.get_value<uint64_t>();
       else if (key == std::string("mainChainParentBlockHash")) alt_chain->m_main_chain_parent_block_hash = it->second.data();
     }
+  }
+
+  std::shared_ptr<monero_alt_chain> monero_alt_chain::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_alt_chain>(json);
   }
 
   rapidjson::Value monero_alt_chain::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -884,6 +920,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_ban> monero_ban::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_ban>(json);
+  }
+
   rapidjson::Value monero_ban::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -912,6 +952,10 @@ namespace monero {
       if (key == std::string("isPruned")) result->m_is_pruned = it->second.get_value<bool>();
       else if (key == std::string("pruningSeed")) result->m_pruning_seed = it->second.get_value<int>();
     }
+  }
+
+  std::shared_ptr<monero_prune_result> monero_prune_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_prune_result>(json);
   }
 
   rapidjson::Value monero_prune_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -947,6 +991,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_mining_status> monero_mining_status::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_mining_status>(json);
+  }
+
   rapidjson::Value monero_mining_status::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -978,6 +1026,10 @@ namespace monero {
       else if (key == std::string("feeSumLow")) sum->m_fee_sum_low = it->second.get_value<uint64_t>();
       else if (key == std::string("feeSumHigh")) sum->m_fee_sum_high = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_miner_tx_sum> monero_miner_tx_sum::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_miner_tx_sum>(json);
   }
 
   rapidjson::Value monero_miner_tx_sum::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1012,6 +1064,10 @@ namespace monero {
       else if (key == std::string("seedHash")) tmplt->m_seed_hash = it->second.data();
       else if (key == std::string("nextSeedHash")) tmplt->m_next_seed_hash = it->second.data();
     }
+  }
+
+  std::shared_ptr<monero_block_template> monero_block_template::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_block_template>(json);
   }
 
   rapidjson::Value monero_block_template::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1063,6 +1119,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_miner_data> monero_miner_data::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_miner_data>(json);
+  }
+
   rapidjson::Value monero_miner_data::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_rpc_payment_info::to_rapidjson_val(allocator);
@@ -1095,6 +1155,10 @@ namespace monero {
       if (key == std::string("id")) aux_pow->m_id = it->second.data();
       else if (key == std::string("hash")) aux_pow->m_hash = it->second.data();
     }
+  }
+
+  std::shared_ptr<monero_auxiliary_pow> monero_auxiliary_pow::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_auxiliary_pow>(json);
   }
 
   rapidjson::Value monero_auxiliary_pow::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1131,6 +1195,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_add_auxiliary_pow_result> monero_add_auxiliary_pow_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_add_auxiliary_pow_result>(json);
+  }
+
   rapidjson::Value monero_add_auxiliary_pow_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_rpc_payment_info::to_rapidjson_val(allocator);
@@ -1165,6 +1233,10 @@ namespace monero {
       else if (key == std::string("size")) span->m_size = it->second.get_value<uint64_t>();
       else if (key == std::string("startHeight")) span->m_start_height = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_connection_span> monero_connection_span::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_connection_span>(json);
   }
 
   rapidjson::Value monero_connection_span::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1230,6 +1302,10 @@ namespace monero {
         else throw monero_error("Invalid RPC peer type, expected 0-4: " + std::to_string(rpc_type));
       }
     }
+  }
+
+  std::shared_ptr<monero_peer> monero_peer::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_peer>(json);
   }
 
   rapidjson::Value monero_peer::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1298,6 +1374,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_submit_tx_result> monero_submit_tx_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_submit_tx_result>(json);
+  }
+
   rapidjson::Value monero_submit_tx_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_rpc_payment_info::to_rapidjson_val(allocator);
@@ -1341,6 +1421,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_output_distribution_entry> monero_output_distribution_entry::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_output_distribution_entry>(json);
+  }
+
   rapidjson::Value monero_output_distribution_entry::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -1368,6 +1452,10 @@ namespace monero {
       else if (key == std::string("unlockedInstances")) entry->m_unlocked_instances = it->second.get_value<uint64_t>();
       else if (key == std::string("recentInstances")) entry->m_recent_instances = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_output_histogram_entry> monero_output_histogram_entry::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_output_histogram_entry>(json);
   }
 
   rapidjson::Value monero_output_histogram_entry::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1408,6 +1496,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_tx_pool_stats> monero_tx_pool_stats::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_tx_pool_stats>(json);
   }
 
   rapidjson::Value monero_tx_pool_stats::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1455,6 +1547,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_daemon_update_check_result> monero_daemon_update_check_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_daemon_update_check_result>(json);
+  }
+
   rapidjson::Value monero_daemon_update_check_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -1484,6 +1580,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_daemon_update_download_result> monero_daemon_update_download_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_daemon_update_download_result>(json);
+  }
+
   rapidjson::Value monero_daemon_update_download_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_daemon_update_check_result::to_rapidjson_val(allocator);
@@ -1511,6 +1611,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_fee_estimate> monero_fee_estimate::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_fee_estimate>(json);
   }
 
   rapidjson::Value monero_fee_estimate::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1577,6 +1681,10 @@ namespace monero {
       else if (key == std::string("isRestricted")) info->m_is_restricted = it->second.get_value<bool>();
       else if (key == std::string("isRegtest")) info->m_is_regtest = it->second.get_value<bool>();
     }
+  }
+
+  std::shared_ptr<monero_daemon_info> monero_daemon_info::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_daemon_info>(json);
   }
 
   rapidjson::Value monero_daemon_info::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1657,6 +1765,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_daemon_sync_info> monero_daemon_sync_info::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_daemon_sync_info>(json);
+  }
+
   rapidjson::Value monero_daemon_sync_info::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_rpc_payment_info::to_rapidjson_val(allocator);
@@ -1694,6 +1806,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_daemon_network_stats> monero_daemon_network_stats::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_daemon_network_stats>(json);
+  }
+
   rapidjson::Value monero_daemon_network_stats::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root = monero_rpc_payment_info::to_rapidjson_val(allocator);
@@ -1726,6 +1842,10 @@ namespace monero {
       else if (key == std::string("window")) info->m_window = it->second.get_value<int>();
       else if (key == std::string("voting")) info->m_voting = it->second.get_value<int>();
     }
+  }
+
+  std::shared_ptr<monero_hard_fork_info> monero_hard_fork_info::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_hard_fork_info>(json);
   }
 
   rapidjson::Value monero_hard_fork_info::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1761,6 +1881,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_generate_blocks_result> monero_generate_blocks_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_generate_blocks_result>(json);
+  }
+
   rapidjson::Value monero_generate_blocks_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
     // create root
     rapidjson::Value root(rapidjson::kObjectType);
@@ -1784,6 +1908,10 @@ namespace monero {
       // note: m_blocks is not round-tripped here; monero_block has no from_property_tree of its own yet
       if (key == std::string("currentHeight")) result->m_current_height = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_get_blocks_by_hash_result> monero_get_blocks_by_hash_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_get_blocks_by_hash_result>(json);
   }
 
   rapidjson::Value monero_get_blocks_by_hash_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1812,6 +1940,10 @@ namespace monero {
       else if (key == std::string("startHeight")) result->m_start_height = it->second.get_value<uint64_t>();
       else if (key == std::string("currentHeight")) result->m_current_height = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_get_block_hashes_result> monero_get_block_hashes_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_get_block_hashes_result>(json);
   }
 
   rapidjson::Value monero_get_block_hashes_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {

--- a/src/daemon/monero_daemon_model.h
+++ b/src/daemon/monero_daemon_model.h
@@ -99,6 +99,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<ssl_options>& options);
+    static std::shared_ptr<ssl_options> deserialize(const std::string& json);
   };
 
   /**
@@ -144,6 +145,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_version>& version);
+    static std::shared_ptr<monero_version> deserialize(const std::string& json);
   };
 
   // forward declarations
@@ -179,6 +181,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block_header>& header);
+    static std::shared_ptr<monero_block_header> deserialize(const std::string& json);
     std::shared_ptr<monero_block_header> copy(const std::shared_ptr<monero_block_header>& src, const std::shared_ptr<monero_block_header>& tgt) const;
     virtual void merge(const std::shared_ptr<monero_block_header>& self, const std::shared_ptr<monero_block_header>& other);
   };
@@ -194,6 +197,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block>& block);
+    static std::shared_ptr<monero_block> deserialize(const std::string& json);
     std::shared_ptr<monero_block> copy(const std::shared_ptr<monero_block>& src, const std::shared_ptr<monero_block>& tgt) const;
     void merge(const std::shared_ptr<monero_block_header>& self, const std::shared_ptr<monero_block_header>& other);
     void merge(const std::shared_ptr<monero_block>& self, const std::shared_ptr<monero_block>& other);
@@ -248,6 +252,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, std::shared_ptr<monero_tx> tx);
+    static std::shared_ptr<monero_tx> deserialize(const std::string& json);
     std::shared_ptr<monero_tx> copy(const std::shared_ptr<monero_tx>& src, const std::shared_ptr<monero_tx>& tgt) const;
     virtual void merge(const std::shared_ptr<monero_tx>& self, const std::shared_ptr<monero_tx>& other);
     boost::optional<uint64_t> get_height() const;
@@ -262,6 +267,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image>& key_image);
+    static std::shared_ptr<monero_key_image> deserialize(const std::string& json);
     static std::vector<std::shared_ptr<monero_key_image>> deserialize_key_images(const std::string& key_images_json);  // TODO: remove this specialty util used once
     std::shared_ptr<monero_key_image> copy(const std::shared_ptr<monero_key_image>& src, const std::shared_ptr<monero_key_image>& tgt) const;
     void merge(const std::shared_ptr<monero_key_image>& self, const std::shared_ptr<monero_key_image>& other);
@@ -281,6 +287,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_output>& output);
+    static std::shared_ptr<monero_output> deserialize(const std::string& json);
     std::shared_ptr<monero_output> copy(const std::shared_ptr<monero_output>& src, const std::shared_ptr<monero_output>& tgt) const;
     virtual void merge(const std::shared_ptr<monero_output>& self, const std::shared_ptr<monero_output>& other);
   };
@@ -303,6 +310,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_rpc_payment_info>& rpc_payment_info);
+    static std::shared_ptr<monero_rpc_payment_info> deserialize(const std::string& json);
   };
 
   /**
@@ -318,6 +326,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_alt_chain>& alt_chain);
+    static std::shared_ptr<monero_alt_chain> deserialize(const std::string& json);
   };
 
   /**
@@ -331,6 +340,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_ban>& ban);
+    static std::shared_ptr<monero_ban> deserialize(const std::string& json);
   };
 
   /**
@@ -341,6 +351,7 @@ namespace monero {
     boost::optional<int> m_pruning_seed;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_prune_result>& result);
+    static std::shared_ptr<monero_prune_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -355,6 +366,7 @@ namespace monero {
     boost::optional<int> m_num_threads;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_mining_status>& status);
+    static std::shared_ptr<monero_mining_status> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -368,6 +380,7 @@ namespace monero {
     boost::optional<uint64_t> m_fee_sum_high;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_miner_tx_sum>& sum);
+    static std::shared_ptr<monero_miner_tx_sum> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -388,6 +401,7 @@ namespace monero {
     boost::optional<uint64_t> m_seed_height;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_block_template>& tmplt);
+    static std::shared_ptr<monero_block_template> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -406,6 +420,7 @@ namespace monero {
     std::vector<std::shared_ptr<monero_tx>> m_tx_pool_backlog;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_miner_data>& data);
+    static std::shared_ptr<monero_miner_data> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -420,6 +435,7 @@ namespace monero {
     monero_auxiliary_pow(const std::string& id, const std::string& hash): m_id(id), m_hash(hash) { }
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_auxiliary_pow>& aux_pow);
+    static std::shared_ptr<monero_auxiliary_pow> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -434,6 +450,7 @@ namespace monero {
     std::vector<std::shared_ptr<monero_auxiliary_pow>> m_aux_pow;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_add_auxiliary_pow_result>& result);
+    static std::shared_ptr<monero_add_auxiliary_pow_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -450,6 +467,7 @@ namespace monero {
     boost::optional<uint64_t> m_start_height;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_connection_span>& span);
+    static std::shared_ptr<monero_connection_span> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -485,6 +503,7 @@ namespace monero {
     boost::optional<monero_connection_type> m_connection_type;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_peer>& peer);
+    static std::shared_ptr<monero_peer> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -508,6 +527,7 @@ namespace monero {
     boost::optional<std::string> m_reason;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_submit_tx_result>& result);
+    static std::shared_ptr<monero_submit_tx_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -528,6 +548,7 @@ namespace monero {
     boost::optional<uint64_t> m_start_height;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_output_distribution_entry>& entry);
+    static std::shared_ptr<monero_output_distribution_entry> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -541,6 +562,7 @@ namespace monero {
     boost::optional<uint64_t> m_recent_instances;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_output_histogram_entry>& entry);
+    static std::shared_ptr<monero_output_histogram_entry> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -564,6 +586,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_pool_stats>& stats);
+    static std::shared_ptr<monero_tx_pool_stats> deserialize(const std::string& json);
   };
 
   /**
@@ -577,6 +600,7 @@ namespace monero {
     boost::optional<std::string> m_user_uri;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_daemon_update_check_result>& check);
+    static std::shared_ptr<monero_daemon_update_check_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -587,6 +611,7 @@ namespace monero {
     boost::optional<std::string> m_download_path;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_daemon_update_download_result>& check);
+    static std::shared_ptr<monero_daemon_update_download_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -599,6 +624,7 @@ namespace monero {
     std::vector<uint64_t> m_fees;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_fee_estimate>& estimate);
+    static std::shared_ptr<monero_fee_estimate> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -642,6 +668,7 @@ namespace monero {
     boost::optional<bool> m_is_regtest;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_daemon_info>& info);
+    static std::shared_ptr<monero_daemon_info> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -657,6 +684,7 @@ namespace monero {
     std::vector<std::shared_ptr<monero_connection_span>> m_spans;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_daemon_sync_info>& info);
+    static std::shared_ptr<monero_daemon_sync_info> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -671,6 +699,7 @@ namespace monero {
     boost::optional<uint64_t> m_total_bytes_out;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_daemon_network_stats>& stats);
+    static std::shared_ptr<monero_daemon_network_stats> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -688,6 +717,7 @@ namespace monero {
     boost::optional<int> m_voting;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_hard_fork_info>& info);
+    static std::shared_ptr<monero_hard_fork_info> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -699,6 +729,7 @@ namespace monero {
     boost::optional<uint64_t> m_height;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_generate_blocks_result>& result);
+    static std::shared_ptr<monero_generate_blocks_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -710,6 +741,7 @@ namespace monero {
     boost::optional<uint64_t> m_current_height; // the daemon's chain height at request time
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_blocks_by_hash_result>& result);
+    static std::shared_ptr<monero_get_blocks_by_hash_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 
@@ -722,6 +754,7 @@ namespace monero {
     boost::optional<uint64_t> m_current_height; // the daemon's chain height at request time
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_get_block_hashes_result>& result);
+    static std::shared_ptr<monero_get_block_hashes_result> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
   };
 

--- a/src/utils/gen_utils.h
+++ b/src/utils/gen_utils.h
@@ -108,6 +108,15 @@ namespace gen_utils
   std::string serialize(const boost::property_tree::ptree& node);
   void deserialize(const std::string& json, boost::property_tree::ptree& root);
 
+  template<typename T>
+  std::shared_ptr<T> deserialize(const std::string& json) {
+    boost::property_tree::ptree root;
+    gen_utils::deserialize(json, root);
+    std::shared_ptr<T> obj = std::make_shared<T>();
+    T::from_property_tree(root, obj);
+    return obj;
+  }
+
   // ------------------------- VALUE RECONCILATION ----------------------------
 
   // TODO: refactor common template code

--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -169,7 +169,10 @@ namespace monero {
         else if (network_type_num == 2) config->m_network_type = monero_network_type::STAGENET;
         else throw std::runtime_error("Invalid network type, expected 0-2: " + std::to_string(network_type_num));
       }
-      else if (key == std::string("server")) config->m_server = monero_rpc_connection::from_property_tree(it->second);
+      else if (key == std::string("server")) {
+        config->m_server = std::make_shared<monero_rpc_connection>();
+        monero_rpc_connection::from_property_tree(it->second, config->m_server);
+      }
       else if (key == std::string("isTrustedDaemon")) config->m_is_trusted_daemon = it->second.get_value<bool>();
       else if (key == std::string("seed")) config->m_seed = it->second.data();
       else if (key == std::string("seedOffset")) config->m_seed_offset = it->second.data();
@@ -187,16 +190,7 @@ namespace monero {
   }
 
   std::shared_ptr<monero_wallet_config> monero_wallet_config::deserialize(const std::string& config_json) {
-
-    // deserialize config json to property node
-    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert config property tree to monero_wallet_config
-    std::shared_ptr<monero_wallet_config> config = std::make_shared<monero_wallet_config>();
-    from_property_tree(node, config);
-    return config;
+    return gen_utils::deserialize<monero_wallet_config>(config_json);
   }
 
   // -------------------------- MONERO SYNC RESULT ----------------------------
@@ -225,6 +219,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_sync_result> monero_sync_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_sync_result>(json);
+  }
+
   // -------------------------- MONERO ACCOUNT -----------------------------
 
   void monero_account::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_account>& account) {
@@ -243,6 +241,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_account> monero_account::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_account>(json);
   }
 
   rapidjson::Value monero_account::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -283,6 +285,10 @@ namespace monero {
       else if (key == std::string("numUnspentOutputs")) subaddress->m_num_unspent_outputs = it->second.get_value<uint64_t>();
       else if (key == std::string("numBlocksToUnlock")) subaddress->m_num_blocks_to_unlock = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_subaddress> monero_subaddress::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_subaddress>(json);
   }
 
   rapidjson::Value monero_subaddress::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -382,6 +388,10 @@ namespace monero {
       else if (key == std::string("numDummyOutputs")) throw std::runtime_error("monero_tx_wallet " + key + " deserialization not implemented");
       else if (key == std::string("extraHex")) throw std::runtime_error("monero_tx_wallet " + key + " deserialization not implemented");
     }
+  }
+
+  std::shared_ptr<monero_tx_wallet> monero_tx_wallet::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_tx_wallet>(json);
   }
 
   std::shared_ptr<monero_tx_wallet> monero_tx_wallet::copy(const std::shared_ptr<monero_tx>& src, const std::shared_ptr<monero_tx>& tgt) const {
@@ -638,6 +648,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_tx_query> monero_tx_query::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_tx_query>(json);
+  }
+
   std::shared_ptr<monero_tx_query> monero_tx_query::deserialize_from_block(const std::string& tx_query_json) {
 
     // deserialize tx query std::string to property rooted at block
@@ -813,6 +827,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_destination> monero_destination::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_destination>(json);
+  }
+
   std::shared_ptr<monero_destination> monero_destination::copy(const std::shared_ptr<monero_destination>& src, const std::shared_ptr<monero_destination>& tgt) const {
     if (this != src.get()) throw std::runtime_error("this destination!= src");
     tgt->m_address = src->m_address;
@@ -840,32 +858,8 @@ namespace monero {
     return root;
   }
 
-  monero_tx_set monero_tx_set::deserialize(const std::string& tx_set_json) {
-
-    // deserialize tx set to property
-    std::istringstream iss = tx_set_json.empty() ? std::istringstream() : std::istringstream(tx_set_json);
-    boost::property_tree::ptree tx_set_node;
-    boost::property_tree::read_json(iss, tx_set_node);
-
-    // initialize tx_set from property node
-    monero_tx_set tx_set;
-    for (boost::property_tree::ptree::const_iterator it = tx_set_node.begin(); it != tx_set_node.end(); ++it) {
-      std::string key = it->first;
-      if (key == std::string("unsignedTxHex")) tx_set.m_unsigned_tx_hex = it->second.data();
-      else if (key == std::string("multisigTxHex")) tx_set.m_multisig_tx_hex = it->second.data();
-      else if (key == std::string("signedTxHex")) tx_set.m_signed_tx_hex = it->second.data();
-      else if (key == std::string("txs")) {
-        boost::property_tree::ptree txs_node = it->second;
-        for (boost::property_tree::ptree::const_iterator it2 = txs_node.begin(); it2 != txs_node.end(); ++it2) {
-          std::shared_ptr<monero_tx_wallet> tx_wallet = std::make_shared<monero_tx_wallet>();
-          monero_tx_wallet::from_property_tree(it2->second, tx_wallet);
-          tx_set.m_txs.push_back(tx_wallet);
-        }
-      }
-      else throw std::runtime_error("monero_utils::deserialize_tx_set() field '" + key + "' not supported");
-    }
-
-    return tx_set;
+  std::shared_ptr<monero_tx_set> monero_tx_set::deserialize(const std::string& tx_set_json) {
+    return gen_utils::deserialize<monero_tx_set>(tx_set_json);
   }
 
   void monero_tx_set::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_set>& set) {
@@ -971,6 +965,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_incoming_transfer> monero_incoming_transfer::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_incoming_transfer>(json);
+  }
+
   std::shared_ptr<monero_incoming_transfer> monero_incoming_transfer::copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const {
     return copy(std::static_pointer_cast<monero_incoming_transfer>(src), std::static_pointer_cast<monero_incoming_transfer>(tgt));
   }
@@ -1033,6 +1031,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_outgoing_transfer> monero_outgoing_transfer::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_outgoing_transfer>(json);
   }
 
   std::shared_ptr<monero_outgoing_transfer> monero_outgoing_transfer::copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const {
@@ -1126,6 +1128,10 @@ namespace monero {
       else if (key == std::string("hasDestinations")) transfer_query->m_has_destinations = it->second.get_value<bool>();
       else if (key == std::string("txQuery")) throw std::runtime_error("monero_transfer_query " + key + " deserialization not implemented");
     }
+  }
+
+  std::shared_ptr<monero_transfer_query> monero_transfer_query::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_transfer_query>(json);
   }
 
   std::shared_ptr<monero_transfer_query> monero_transfer_query::deserialize_from_block(const std::string& transfer_query_json) {
@@ -1294,6 +1300,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_output_wallet> monero_output_wallet::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_output_wallet>(json);
+  }
+
   std::shared_ptr<monero_output_wallet> monero_output_wallet::copy(const std::shared_ptr<monero_output>& src, const std::shared_ptr<monero_output>& tgt) const {
     MTRACE("monero_output_wallet::copy(output)");
     return monero_output_wallet::copy(std::static_pointer_cast<monero_output_wallet>(src), std::static_pointer_cast<monero_output_wallet>(tgt));
@@ -1363,6 +1373,10 @@ namespace monero {
       else if (key == std::string("maxAmount")) output_query->m_max_amount = it->second.get_value<uint64_t>();
       else if (key == std::string("txQuery")) {} // ignored
     }
+  }
+
+  std::shared_ptr<monero_output_query> monero_output_query::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_output_query>(json);
   }
 
   std::shared_ptr<monero_output_query> monero_output_query::deserialize_from_block(const std::string& output_query_json) {
@@ -1552,16 +1566,7 @@ namespace monero {
   }
 
   std::shared_ptr<monero_tx_config> monero_tx_config::deserialize(const std::string& config_json) {
-
-    // deserialize config json to property node
-    std::istringstream iss = config_json.empty() ? std::istringstream() : std::istringstream(config_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert config property tree to monero_tx_config
-    std::shared_ptr<monero_tx_config> config = std::make_shared<monero_tx_config>();
-    from_property_tree(node, config);
-    return config;
+    return gen_utils::deserialize<monero_tx_config>(config_json);
   }
 
   std::vector<std::shared_ptr<monero_destination>> monero_tx_config::get_normalized_destinations() const {
@@ -1604,6 +1609,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_integrated_address> monero_integrated_address::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_integrated_address>(json);
+  }
+
   // -------------------- MONERO KEY IMAGE EXPORT RESULT ----------------------
 
   rapidjson::Value monero_key_image_export_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1637,16 +1646,7 @@ namespace monero {
   }
 
   std::shared_ptr<monero_key_image_export_result> monero_key_image_export_result::deserialize(const std::string& result_json) {
-
-    // deserialize json to property node
-    std::istringstream iss = result_json.empty() ? std::istringstream() : std::istringstream(result_json);
-    boost::property_tree::ptree node;
-    boost::property_tree::read_json(iss, node);
-
-    // convert property tree to export result
-    std::shared_ptr<monero_key_image_export_result> result = std::make_shared<monero_key_image_export_result>();
-    from_property_tree(node, result);
-    return result;
+    return gen_utils::deserialize<monero_key_image_export_result>(result_json);
   }
 
   // -------------------- MONERO KEY IMAGE IMPORT RESULT ----------------------
@@ -1658,6 +1658,10 @@ namespace monero {
       else if (key == std::string("spentAmount")) result->m_spent_amount = it->second.get_value<uint64_t>();
       else if (key == std::string("unspentAmount")) result->m_unspent_amount = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_key_image_import_result> monero_key_image_import_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_key_image_import_result>(json);
   }
 
   rapidjson::Value monero_key_image_import_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1690,6 +1694,10 @@ namespace monero {
       }
       else if (key == std::string("version")) result->m_version = it->second.get_value<uint32_t>();
     }
+  }
+
+  std::shared_ptr<monero_message_signature_result> monero_message_signature_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_message_signature_result>(json);
   }
 
   rapidjson::Value monero_message_signature_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1734,6 +1742,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_check> monero_check::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_check>(json);
+  }
+
   // --------------------------- MONERO CHECK TX ------------------------------
 
   void monero_check_tx::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check_tx>& check) {
@@ -1744,6 +1756,10 @@ namespace monero {
       else if (key == std::string("numConfirmations")) check->m_num_confirmations = it->second.get_value<uint64_t>();
       else if (key == std::string("receivedAmount")) check->m_received_amount = it->second.get_value<uint64_t>();
     }
+  }
+
+  std::shared_ptr<monero_check_tx> monero_check_tx::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_check_tx>(json);
   }
 
   rapidjson::Value monero_check_tx::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1788,6 +1804,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_check_reserve> monero_check_reserve::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_check_reserve>(json);
+  }
+
   // --------------------------- MONERO MULTISIG ------------------------------
 
   void monero_multisig_info::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_multisig_info>& info) {
@@ -1798,6 +1818,10 @@ namespace monero {
       else if (key == std::string("threshold")) info->m_threshold = it->second.get_value<uint32_t>();
       else if (key == std::string("numParticipants")) info->m_num_participants = it->second.get_value<uint32_t>();
     }
+  }
+
+  std::shared_ptr<monero_multisig_info> monero_multisig_info::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_multisig_info>(json);
   }
 
   rapidjson::Value monero_multisig_info::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1826,6 +1850,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_multisig_init_result> monero_multisig_init_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_multisig_init_result>(json);
+  }
+
   rapidjson::Value monero_multisig_init_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
 
     // create root
@@ -1850,6 +1878,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_multisig_sign_result> monero_multisig_sign_result::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_multisig_sign_result>(json);
   }
 
   rapidjson::Value monero_multisig_sign_result::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {
@@ -1897,6 +1929,10 @@ namespace monero {
       else if (key == std::string("description")) entry->m_description = it->second.data();
       else if (key == std::string("paymentId")) entry->m_payment_id = it->second.data();
     }
+  }
+
+  std::shared_ptr<monero_address_book_entry> monero_address_book_entry::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_address_book_entry>(json);
   }
 
   // -------------------------- MONERO COMPARATORS ---------------------------
@@ -2012,6 +2048,10 @@ namespace monero {
     }
   }
 
+  std::shared_ptr<monero_decoded_address> monero_decoded_address::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_decoded_address>(json);
+  }
+
   // --------------------------- MONERO ACCOUNT TAG ---------------------------
 
   void monero_account_tag::from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_account_tag>& account_tag) {
@@ -2025,6 +2065,10 @@ namespace monero {
         }
       }
     }
+  }
+
+  std::shared_ptr<monero_account_tag> monero_account_tag::deserialize(const std::string& json) {
+    return gen_utils::deserialize<monero_account_tag>(json);
   }
 
   rapidjson::Value monero_account_tag::to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const {

--- a/src/wallet/monero_wallet_model.h
+++ b/src/wallet/monero_wallet_model.h
@@ -103,6 +103,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_sync_result>& result);
+    static std::shared_ptr<monero_sync_result> deserialize(const std::string& json);
   };
 
   /**
@@ -121,6 +122,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_subaddress>& subaddress);
+    static std::shared_ptr<monero_subaddress> deserialize(const std::string& json);
   };
 
   /**
@@ -136,6 +138,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_account>& account);
+    static std::shared_ptr<monero_account> deserialize(const std::string& json);
   };
 
   /**
@@ -148,6 +151,7 @@ namespace monero {
     monero_destination(boost::optional<std::string> address = boost::none, boost::optional<uint64_t> amount = boost::none) : m_address(address), m_amount(amount) {}
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_destination>& destination);
+    static std::shared_ptr<monero_destination> deserialize(const std::string& json);
     std::shared_ptr<monero_destination> copy(const std::shared_ptr<monero_destination>& src, const std::shared_ptr<monero_destination>& tgt) const;
   };
 
@@ -188,6 +192,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_incoming_transfer>& transfer);
+    static std::shared_ptr<monero_incoming_transfer> deserialize(const std::string& json);
     std::shared_ptr<monero_incoming_transfer> copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const;
     std::shared_ptr<monero_incoming_transfer> copy(const std::shared_ptr<monero_incoming_transfer>& src, const std::shared_ptr<monero_incoming_transfer>& tgt) const;
     boost::optional<bool> is_incoming() const;
@@ -205,6 +210,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_outgoing_transfer>& transfer);
+    static std::shared_ptr<monero_outgoing_transfer> deserialize(const std::string& json);
     std::shared_ptr<monero_outgoing_transfer> copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const;
     std::shared_ptr<monero_outgoing_transfer> copy(const std::shared_ptr<monero_outgoing_transfer>& src, const std::shared_ptr<monero_outgoing_transfer>& tgt) const;
     boost::optional<bool> is_incoming() const;
@@ -229,6 +235,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_transfer_query>& transfer_query);
+    static std::shared_ptr<monero_transfer_query> deserialize(const std::string& json);
     static std::shared_ptr<monero_transfer_query> deserialize_from_block(const std::string& transfer_query_json);
     static bool is_contextual(const monero_transfer_query& query);
     std::shared_ptr<monero_transfer_query> copy(const std::shared_ptr<monero_transfer>& src, const std::shared_ptr<monero_transfer>& tgt) const;
@@ -248,6 +255,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_output_wallet>& output_wallet);
+    static std::shared_ptr<monero_output_wallet> deserialize(const std::string& json);
     std::shared_ptr<monero_output_wallet> copy(const std::shared_ptr<monero_output>& src, const std::shared_ptr<monero_output>& tgt) const;
     std::shared_ptr<monero_output_wallet> copy(const std::shared_ptr<monero_output_wallet>& src, const std::shared_ptr<monero_output_wallet>& tgt) const;
     void merge(const std::shared_ptr<monero_output>& self, const std::shared_ptr<monero_output>& other);
@@ -269,6 +277,7 @@ namespace monero {
     //boost::property_tree::ptree to_property_tree() const;
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_output_query>& output_query);
+    static std::shared_ptr<monero_output_query> deserialize(const std::string& json);
     static std::shared_ptr<monero_output_query> deserialize_from_block(const std::string& output_query_json);
     static bool is_contextual(const monero_output_query& query);
     std::shared_ptr<monero_output_query> copy(const std::shared_ptr<monero_output>& src, const std::shared_ptr<monero_output>& tgt) const;
@@ -296,6 +305,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_wallet>& tx_wallet);
+    static std::shared_ptr<monero_tx_wallet> deserialize(const std::string& json);
     std::shared_ptr<monero_tx_wallet> copy(const std::shared_ptr<monero_tx>& src, const std::shared_ptr<monero_tx>& tgt) const;
     std::shared_ptr<monero_tx_wallet> copy(const std::shared_ptr<monero_tx_wallet>& src, const std::shared_ptr<monero_tx_wallet>& tgt) const;
     void merge(const std::shared_ptr<monero_tx>& self, const std::shared_ptr<monero_tx>& other);
@@ -332,6 +342,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_query>& tx_query);
+    static std::shared_ptr<monero_tx_query> deserialize(const std::string& json);
     static std::shared_ptr<monero_tx_query> deserialize_from_block(const std::string& tx_query_json);
 
     /**
@@ -366,7 +377,7 @@ namespace monero {
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_tx_set>& set);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
-    static monero_tx_set deserialize(const std::string& tx_set_json);
+    static std::shared_ptr<monero_tx_set> deserialize(const std::string& tx_set_json);
   };
 
   /**
@@ -379,6 +390,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_integrated_address>& subaddress);
+    static std::shared_ptr<monero_integrated_address> deserialize(const std::string& json);
   };
 
   /**
@@ -444,6 +456,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_key_image_import_result>& result);
+    static std::shared_ptr<monero_key_image_import_result> deserialize(const std::string& json);
   };
 
   /**
@@ -465,6 +478,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_message_signature_result> result);
+    static std::shared_ptr<monero_message_signature_result> deserialize(const std::string& json);
   };
 
   /**
@@ -475,6 +489,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check>& check);
+    static std::shared_ptr<monero_check> deserialize(const std::string& json);
   };
 
   /**
@@ -487,6 +502,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check_tx>& check);
+    static std::shared_ptr<monero_check_tx> deserialize(const std::string& json);
   };
 
   /**
@@ -498,6 +514,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_check_reserve>& check);
+    static std::shared_ptr<monero_check_reserve> deserialize(const std::string& json);
   };
 
   /**
@@ -511,6 +528,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_multisig_info>& info);
+    static std::shared_ptr<monero_multisig_info> deserialize(const std::string& json);
   };
 
   /**
@@ -524,6 +542,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_multisig_init_result>& res);
+    static std::shared_ptr<monero_multisig_init_result> deserialize(const std::string& json);
   };
 
   /**
@@ -535,6 +554,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_multisig_sign_result>& res);
+    static std::shared_ptr<monero_multisig_sign_result> deserialize(const std::string& json);
   };
 
   /**
@@ -551,6 +571,7 @@ namespace monero {
     monero_address_book_entry(uint64_t index, const std::string& address, const std::string& description, const std::string& payment_id) : m_index(index), m_address(address), m_description(description), m_payment_id(payment_id) {}
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_address_book_entry>& entry);
+    static std::shared_ptr<monero_address_book_entry> deserialize(const std::string& json);
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const;
   };
 
@@ -598,6 +619,7 @@ namespace monero {
 
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_decoded_address>& address);
+    static std::shared_ptr<monero_decoded_address> deserialize(const std::string& json);
   };
 
   /**
@@ -615,6 +637,7 @@ namespace monero {
     rapidjson::Value to_rapidjson_val(rapidjson::Document::AllocatorType& allocator) const override;
 
     static void from_property_tree(const boost::property_tree::ptree& node, const std::shared_ptr<monero_account_tag>& account_tag);
+    static std::shared_ptr<monero_account_tag> deserialize(const std::string& json);
   };
 
 }


### PR DESCRIPTION
* Implement template gen_utils::deserialize
* Normalize monero_rpc_connection::from_property_tree
* Implement deserialize methods for all public data structures
* breaking change: now monero_tx_set::deseriliaze returns a std::shared_ptr