### PR TITLE
model: parse networkType as signed in wallet config deserializer

### DIFF
--- a/src/wallet/monero_wallet_model.cpp
+++ b/src/wallet/monero_wallet_model.cpp
@@ -163,7 +163,7 @@ namespace monero {
       if (key == std::string("path")) config->m_path = it->second.data();
       else if (key == std::string("password")) config->m_password = it->second.data();
       else if (key == std::string("networkType")) {
-        uint32_t network_type_num = it->second.get_value<uint32_t>();
+        int64_t network_type_num = it->second.get_value<int64_t>();
         if (network_type_num == 0) config->m_network_type = monero_network_type::MAINNET;
         else if (network_type_num == 1) config->m_network_type = monero_network_type::TESTNET;
         else if (network_type_num == 2) config->m_network_type = monero_network_type::STAGENET;


### PR DESCRIPTION
Read networkType as int64_t so negative values fail range validation instead of wrapping to a valid unsigned enum value.